### PR TITLE
Feature/UI show state and times

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,17 +36,19 @@ tasks:
     deps:
         desc: Install frontend deps (clean, reproducible)
         cmds:
-            - npm ci --prefix {{.FRONTEND_DIR}}
+            - cd frontend
+            - npm ci
 
     dev:
         desc: Start Wails dev server (installs deps on first run)
         deps: [ ensure-dist ]
         cmds:
             - |
+                cd frontend
                 {{if eq OS "windows"}}
-                powershell -NoProfile -Command "if (-Not (Test-Path '{{.FRONTEND_DIR}}/node_modules')) { npm ci --prefix '{{.FRONTEND_DIR}}' } else { npm install --prefix '{{.FRONTEND_DIR}}' }"
+                powershell -NoProfile -Command "if (-Not (Test-Path 'node_modules')) { npm ci } else { npm install }"
                 {{else}}
-                bash -lc 'if [ -d "{{.FRONTEND_DIR}}/node_modules" ]; then npm ci --prefix {{.FRONTEND_DIR}}; else npm install --prefix {{.FRONTEND_DIR}}; fi'
+                bash -lc 'if [ -d "node_modules" ]; then npm ci; else npm install; fi'
                 {{end}}
             - wails dev
 
@@ -79,10 +81,11 @@ tasks:
                 bash -lc 'command -v golangci-lint >/dev/null && golangci-lint run || echo "skipping: golangci-lint not installed"'
                 {{end}}
             - |
+                cd frontend
                 {{if eq OS "windows"}}
-                powershell -NoProfile -Command "if (Test-Path '{{.FRONTEND_DIR}}/package.json') { if (npm -s --prefix '{{.FRONTEND_DIR}}' run | Select-String '^  lint') { npm run -s --prefix '{{.FRONTEND_DIR}}' lint } else { Write-Host 'frontend: no lint script' } } else { Write-Host 'no frontend dir' }"
+                powershell -NoProfile -Command "if (Test-Path 'package.json') { if (npm -s run | Select-String '^  lint') { npm run -s lint } else { Write-Host 'frontend: no lint script' } } else { Write-Host 'no frontend dir' }"
                 {{else}}
-                bash -lc 'if [ -f "{{.FRONTEND_DIR}}/package.json" ] && npm -s --prefix {{.FRONTEND_DIR}} run | grep -q "^  lint"; then npm run -s --prefix {{.FRONTEND_DIR}} lint; else echo "frontend: no lint script"; fi'
+                bash -lc 'if [ -f "package.json" ] && npm -s run | grep -q "^  lint"; then npm run -s lint; else echo "frontend: no lint script"; fi'
                 {{end}}
 
     fmt:
@@ -95,10 +98,11 @@ tasks:
                 bash -lc 'command -v gofumpt >/dev/null && gofumpt -w . || gofmt -s -w .'
                 {{end}}
             - |
+                cd frontend
                 {{if eq OS "windows"}}
-                powershell -NoProfile -Command "if (Test-Path '{{.FRONTEND_DIR}}/package.json') { if (npm -s --prefix '{{.FRONTEND_DIR}}' run | Select-String '^  fmt') { npm run -s --prefix '{{.FRONTEND_DIR}}' fmt } else { npx -y prettier@latest --loglevel warn --write '{{.FRONTEND_DIR}}/**/*.{ts,tsx,js,jsx,css,scss,html,json,md}' } }"
+                powershell -NoProfile -Command "if (Test-Path 'package.json') { if (npm -s run | Select-String '^  fmt') { npm run -s fmt } else { npx -y prettier@latest --loglevel warn --write '**/*.{ts,tsx,js,jsx,css,scss,html,json,md}' } }"
                 {{else}}
-                bash -lc 'if [ -f "{{.FRONTEND_DIR}}/package.json" ] && npm -s --prefix {{.FRONTEND_DIR}} run | grep -q "^  fmt"; then npm run -s --prefix {{.FRONTEND_DIR}} fmt; else npx -y prettier@latest --loglevel warn --write "{{.FRONTEND_DIR}}/**/*.{ts,tsx,js,jsx,css,scss,html,json,md}"; fi'
+                bash -lc 'if [ -f "package.json" ] && npm -s run | grep -q "^  fmt"; then npm run -s fmt; else npx -y prettier@latest --loglevel warn --write "**/*.{ts,tsx,js,jsx,css,scss,html,json,md}"; fi'
                 {{end}}
 
     release:

--- a/frontend/src/components/splitter/SplitList.tsx
+++ b/frontend/src/components/splitter/SplitList.tsx
@@ -1,25 +1,21 @@
 import { session } from "../../../wailsjs/go/models";
-import { formatDuration, stringToParts } from "./Timer";
+import {displayFormattedTimeParts, formatDuration, stringToParts} from "./Timer";
 import { useEffect, useState } from "react";
 import { GetLoadedSplitFile, GetSessionStatus } from "../../../wailsjs/go/session/Service";
 import { EventsOn } from "../../../wailsjs/runtime";
 import SplitFilePayload = session.SplitFilePayload;
-import SegmentPayload = session.SegmentPayload;
+import ServicePayload = session.ServicePayload;
 
 export type CompareAgainst = "best" | "average";
 
-type SplitPayload = {
-    split_index: number;
-    new_index: number;
-    split_segment: SegmentPayload;
-    new_segment: SegmentPayload;
-    finished: boolean;
-    current_time: string;
-};
+type Completion = {
+    time: string;
+}
 
 export default function SplitList() {
     const [currentSegment, setCurrentSegment] = useState<number | null>(null);
     const [splitFile, setSplitFile] = useState<session.SplitFilePayload | null>(null);
+    const [completions, setCompletions] = useState<Completion[]>([]);
     const [compareAgainst, setCompareAgainst] = useState<CompareAgainst | null>(null);
 
     useEffect(() => {
@@ -31,13 +27,22 @@ export default function SplitList() {
         (async () => {
             console.log("fetching session data...");
             const session = await GetSessionStatus();
-            if (session.current_segment) {
+            if (session.current_segment !== undefined) {
                 setCurrentSegment(session.current_segment_index);
             }
         })();
 
-        const unsubscribeFromSplitUpdates = EventsOn("session:split", (splitPayload: SplitPayload) => {
-            setCurrentSegment(splitPayload.new_index);
+        const unsubscribeFromSplitUpdates = EventsOn("session:update", (servicePayload: ServicePayload) => {
+            console.log("received service update:", servicePayload);
+            setCurrentSegment(servicePayload.current_segment_index);
+            if (servicePayload.current_run) {
+                setCompletions(
+                    servicePayload.current_run.split_payloads.map((c, i) => {
+                        return {time: displayFormattedTimeParts(formatDuration(stringToParts(c.current_time)))}
+                    }));
+            } else {
+                setCompletions([])
+            }
         });
 
         const unsubscribeFromSplitFileUpdates = EventsOn("splitfile:update", (splitFilePayload: SplitFilePayload) => {
@@ -51,17 +56,23 @@ export default function SplitList() {
         };
     }, []);
 
-    const formattedSegments = splitFile?.segments.map((segment, index) => {
-        const time = compareAgainst === "average" ? segment.average_time : segment.best_time;
-        const formattedParts = formatDuration(stringToParts(time));
-        return `${formattedParts.hoursText}${formattedParts.sepHM}${formattedParts.minutesText}${formattedParts.sepMS}${formattedParts.secondsText}`;
-    });
+    const getSegmentDisplayTime = (index: number): string => {
+        if(index < completions.length) {
+            return completions[index].time;
+        } else {
+            console.log(splitFile?.segments)
+            const avg = splitFile?.segments[index].average_time
+            const best = splitFile?.segments[index].best_time
+            return compareAgainst == "best" ? displayFormattedTimeParts(formatDuration(stringToParts(best ?? "-"))) :
+                displayFormattedTimeParts(formatDuration(stringToParts(avg ?? "-")));
+        }
+    }
 
     const segmentRows = splitFile?.segments.map((segment, index) => (
         <tr key={segment.id ?? index} className={currentSegment !== null && currentSegment === index ? "selected" : ""}>
             <td className="splitName">{segment.name}</td>
             <td className="splitComparison">
-                <strong>{formattedSegments && formattedSegments[index]}</strong>
+                <strong>{getSegmentDisplayTime(index)}</strong>
             </td>
         </tr>
     ));

--- a/frontend/src/components/splitter/Splitter.tsx
+++ b/frontend/src/components/splitter/Splitter.tsx
@@ -21,7 +21,7 @@ export default function Splitter() {
         {
             label: "Load Splits",
             onClick: async () => {
-                await LoadSplitFile();
+                await LoadSplitFile().catch((err) => console.log(err));
             },
         },
         {

--- a/frontend/src/components/splitter/Timer.tsx
+++ b/frontend/src/components/splitter/Timer.tsx
@@ -129,3 +129,17 @@ export function formatDuration(timeParts: TimeParts): FormattedTimeParts {
         centisText: centisText,
     };
 }
+
+export function displayFormattedTimeParts(formattedParts: FormattedTimeParts): string {
+    let timeString = ""
+    if (formattedParts.showHours) {
+        timeString += formattedParts.hoursText;
+    }
+
+    if (formattedParts.showMinutes) {
+        timeString += `${formattedParts.sepHM}${formattedParts.minutesText}`;
+    }
+
+    timeString += `${formattedParts.sepMS}${formattedParts.secondsText}${formattedParts.sepSC}${formattedParts.centisText}`;
+    return timeString
+}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -68,6 +68,39 @@ export namespace session {
 		    return a;
 		}
 	}
+	export class PBStatsPayload {
+	    run?: RunPayload;
+	    total: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new PBStatsPayload(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.run = this.convertValues(source["run"], RunPayload);
+	        this.total = source["total"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
 	export class SegmentPayload {
 	    id: string;
 	    name: string;
@@ -86,6 +119,56 @@ export namespace session {
 	        this.average_time = source["average_time"];
 	    }
 	}
+	export class StatTimePayload {
+	    id: string;
+	    time: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new StatTimePayload(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.time = source["time"];
+	    }
+	}
+	export class SplitFileStatsPayload {
+	    golds: StatTimePayload[];
+	    averages: StatTimePayload[];
+	    sob: string;
+	    pb?: PBStatsPayload;
+	
+	    static createFrom(source: any = {}) {
+	        return new SplitFileStatsPayload(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.golds = this.convertValues(source["golds"], StatTimePayload);
+	        this.averages = this.convertValues(source["averages"], StatTimePayload);
+	        this.sob = source["sob"];
+	        this.pb = this.convertValues(source["pb"], PBStatsPayload);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class SplitFilePayload {
 	    id: number[];
 	    version: number;
@@ -94,6 +177,7 @@ export namespace session {
 	    segments: SegmentPayload[];
 	    attempts: number;
 	    runs: RunPayload[];
+	    stats: SplitFileStatsPayload;
 	
 	    static createFrom(source: any = {}) {
 	        return new SplitFilePayload(source);
@@ -108,6 +192,7 @@ export namespace session {
 	        this.segments = this.convertValues(source["segments"], SegmentPayload);
 	        this.attempts = source["attempts"];
 	        this.runs = this.convertValues(source["runs"], RunPayload);
+	        this.stats = this.convertValues(source["stats"], SplitFileStatsPayload);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -172,6 +257,8 @@ export namespace session {
 		    return a;
 		}
 	}
+	
+	
 	
 
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -32,10 +32,10 @@ export namespace session {
 	}
 	export class RunPayload {
 	    id: number[];
-	    splitFileVersion: number;
-	    totalTime: number;
+	    splitfile_version: number;
+	    total_time: number;
 	    completed: boolean;
-	    splitPayloads: SplitPayload[];
+	    split_payloads: SplitPayload[];
 	
 	    static createFrom(source: any = {}) {
 	        return new RunPayload(source);
@@ -44,10 +44,10 @@ export namespace session {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
-	        this.splitFileVersion = source["splitFileVersion"];
-	        this.totalTime = source["totalTime"];
+	        this.splitfile_version = source["splitfile_version"];
+	        this.total_time = source["total_time"];
 	        this.completed = source["completed"];
-	        this.splitPayloads = this.convertValues(source["splitPayloads"], SplitPayload);
+	        this.split_payloads = this.convertValues(source["split_payloads"], SplitPayload);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -136,6 +136,7 @@ export namespace session {
 	    paused: boolean;
 	    current_time: number;
 	    current_time_formatted: string;
+	    current_run?: RunPayload;
 	
 	    static createFrom(source: any = {}) {
 	        return new ServicePayload(source);
@@ -150,6 +151,7 @@ export namespace session {
 	        this.paused = source["paused"];
 	        this.current_time = source["current_time"];
 	        this.current_time_formatted = source["current_time_formatted"];
+	        this.current_run = this.convertValues(source["current_run"], RunPayload);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/session/jsonfile.go
+++ b/session/jsonfile.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -59,9 +60,9 @@ func NewJsonFile(runtime RuntimeProvider, fileProvider FileProvider) *JsonFile {
 	}
 }
 
-// Startup is called either directly by Wails.Run OnStartup, or by something else in that chain.
+// Startup is called either directly by Wails.run OnStartup, or by something else in that chain.
 //
-// The specific context.Context must be provided by Wails.Run OnStartup or opening save/load file dialogs will panic.
+// The specific context.Context must be provided by Wails.run OnStartup or opening save/load file dialogs will panic.
 func (j *JsonFile) Startup(ctx context.Context) {
 	j.ctx = ctx
 }
@@ -94,7 +95,7 @@ func (j *JsonFile) Save(splitFilePayload SplitFilePayload) error {
 
 		if filename == "" {
 			logger.Debug("user cancelled save")
-			return UserCancelledSave{}
+			return UserCancelledSave{errors.New("user cancelled save")}
 		}
 
 		j.fileName = filename
@@ -138,8 +139,8 @@ func (j *JsonFile) Load() (SplitFilePayload, error) {
 	}
 
 	if filename == "" {
-		logger.Debug("user cancelled save")
-		return SplitFilePayload{}, UserCancelledSave{}
+		logger.Debug("user cancelled load")
+		return SplitFilePayload{}, UserCancelledSave{errors.New("user cancelled load")}
 	}
 
 	j.fileName = filename

--- a/session/run.go
+++ b/session/run.go
@@ -8,10 +8,10 @@ import (
 
 type RunPayload struct {
 	ID               uuid.UUID      `json:"id"`
-	SplitFileVersion int            `json:"splitFileVersion"`
-	TotalTime        time.Duration  `json:"totalTime"`
+	SplitFileVersion int            `json:"splitfile_version"`
+	TotalTime        time.Duration  `json:"total_time"`
 	Completed        bool           `json:"completed"`
-	SplitPayloads    []SplitPayload `json:"splitPayloads"`
+	SplitPayloads    []SplitPayload `json:"split_payloads"`
 }
 
 // Run maintains the history attempts in a SplitFile.
@@ -25,6 +25,9 @@ type Run struct {
 	splitPayloads    []SplitPayload
 }
 
+// GetPayload returns a snapshot of a Run
+//
+// GetPayload, modify the payload, then send it to NewRunFromPayload and persist the result of that to make changes.
 func (r *Run) GetPayload() RunPayload {
 	return RunPayload{
 		ID:               r.id,
@@ -35,6 +38,9 @@ func (r *Run) GetPayload() RunPayload {
 	}
 }
 
+// NewRunFromPayload creates a new Run from a RunPayload.
+//
+// Useful for making stateful updates to a Run without exposing internal data structure or presentation.
 func NewRunFromPayload(payload RunPayload) Run {
 	return Run{
 		id:               payload.ID,

--- a/session/run.go
+++ b/session/run.go
@@ -25,10 +25,10 @@ type Run struct {
 	splitPayloads    []SplitPayload
 }
 
-// GetPayload returns a snapshot of a Run
+// getPayload returns a snapshot of a Run
 //
-// GetPayload, modify the payload, then send it to NewRunFromPayload and persist the result of that to make changes.
-func (r *Run) GetPayload() RunPayload {
+// getPayload, modify the payload, then send it to newRunFromPayload and persist the result of that to make changes.
+func (r *Run) getPayload() RunPayload {
 	return RunPayload{
 		ID:               r.id,
 		SplitFileVersion: r.splitFileVersion,
@@ -38,10 +38,10 @@ func (r *Run) GetPayload() RunPayload {
 	}
 }
 
-// NewRunFromPayload creates a new Run from a RunPayload.
+// newRunFromPayload creates a new Run from a RunPayload.
 //
 // Useful for making stateful updates to a Run without exposing internal data structure or presentation.
-func NewRunFromPayload(payload RunPayload) Run {
+func newRunFromPayload(payload RunPayload) Run {
 	return Run{
 		id:               payload.ID,
 		splitFileVersion: payload.SplitFileVersion,

--- a/session/segment.go
+++ b/session/segment.go
@@ -2,9 +2,10 @@ package session
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/zellydev-games/opensplit/logger"
 	"github.com/zellydev-games/opensplit/utils"
-	"time"
 
 	"github.com/google/uuid"
 )

--- a/session/segment_test.go
+++ b/session/segment_test.go
@@ -37,6 +37,6 @@ func TestGetPayload(t *testing.T) {
 		payload.Name != "Test Segment" ||
 		payload.Average != "00:00:02.00" ||
 		payload.BestTime != "00:00:01.00" {
-		t.Errorf("GetPayload did not return expected payload got %v", payload)
+		t.Errorf("getPayload did not return expected payload got %v", payload)
 	}
 }

--- a/session/segment_test.go
+++ b/session/segment_test.go
@@ -35,8 +35,8 @@ func TestGetPayload(t *testing.T) {
 	payload := s.GetPayload()
 	if payload.ID != "4bc1a05c-d4f3-4095-887f-519e2fbb54f3" ||
 		payload.Name != "Test Segment" ||
-		payload.Average != "0:00:02.00" ||
-		payload.BestTime != "0:00:01.00" {
+		payload.Average != "00:00:02.00" ||
+		payload.BestTime != "00:00:01.00" {
 		t.Errorf("GetPayload did not return expected payload got %v", payload)
 	}
 }

--- a/session/service_test.go
+++ b/session/service_test.go
@@ -156,7 +156,7 @@ func TestServiceSplit(t *testing.T) {
 	}
 
 	if len(sf.runs) > 0 {
-		t.Error("first split on new file added Run prematurely")
+		t.Error("first split on new file added run prematurely")
 	}
 
 	// second split
@@ -312,7 +312,7 @@ func TestNewSplitFile(t *testing.T) {
 	_ = s.UpdateSplitFile(payload)
 	emptyUUID := uuid.UUID{}
 	if s.loadedSplitFile.id == emptyUUID {
-		t.Error("session UpdateSplitFile did not create a new ID with a new splitfile")
+		t.Error("session UpdateSplitFile did not create a new id with a new splitfile")
 	}
 
 	if s.loadedSplitFile.version != 1 {

--- a/session/stats.go
+++ b/session/stats.go
@@ -1,0 +1,178 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zellydev-games/opensplit/logger"
+	"github.com/zellydev-games/opensplit/utils"
+)
+
+type StatTimePayload struct {
+	ID   string `json:"id"`
+	Time string `json:"time"`
+}
+
+type StatTime struct {
+	id   uuid.UUID
+	time time.Duration
+}
+
+type PBStatsPayload struct {
+	Run   *RunPayload `json:"run"`
+	Total string      `json:"total"`
+}
+
+type PBStats struct {
+	run   *RunPayload
+	total time.Duration
+}
+
+type SplitFileStatsPayload struct {
+	Golds    []StatTimePayload `json:"golds"`
+	Averages []StatTimePayload `json:"averages"`
+	SoB      string            `json:"sob"`
+	PB       *PBStatsPayload   `json:"pb"`
+}
+
+type SplitFileStats struct {
+	golds    []StatTime
+	averages []StatTime
+	sob      time.Duration
+	pb       *PBStats
+}
+
+func (s *SplitFileStats) GetPayload() (SplitFileStatsPayload, error) {
+	var goldPayloads []StatTimePayload
+	var averagesPayloads []StatTimePayload
+
+	for _, gold := range s.golds {
+		goldPayloads = append(goldPayloads, StatTimePayload{
+			ID:   gold.id.String(),
+			Time: utils.FormatTimeToString(gold.time),
+		})
+	}
+
+	for _, average := range s.averages {
+		averagesPayloads = append(averagesPayloads, StatTimePayload{
+			ID:   average.id.String(),
+			Time: utils.FormatTimeToString(average.time),
+		})
+	}
+
+	var pbPayload *PBStatsPayload
+	if s.pb != nil {
+		pbPayload = &PBStatsPayload{
+			Run:   s.pb.run,
+			Total: utils.FormatTimeToString(s.pb.total),
+		}
+	}
+
+	return SplitFileStatsPayload{
+		Golds:    goldPayloads,
+		Averages: averagesPayloads,
+		SoB:      utils.FormatTimeToString(s.sob),
+		PB:       pbPayload,
+	}, nil
+}
+
+func (s *SplitFile) stats() SplitFileStats {
+	goldMap, sumMap, countMap := perSegmentAggregates(s.runs)
+
+	golds := make([]StatTime, 0, len(s.segments))
+	averages := make([]StatTime, 0, len(s.segments))
+	var sob time.Duration
+
+	for _, seg := range s.segments {
+		if g, ok := goldMap[seg.id]; ok {
+			golds = append(golds, StatTime{seg.id, g})
+			sob += g
+		}
+
+		if sum, ok := sumMap[seg.id]; ok {
+			avg := sum / time.Duration(countMap[seg.id])
+			averages = append(averages, StatTime{seg.id, avg})
+		}
+	}
+
+	pb, err := getPB(s.runs)
+	if err != nil {
+		logger.Debug(fmt.Sprintf("No pb found: %s", err))
+		pb = nil
+	}
+
+	return SplitFileStats{
+		golds:    golds,
+		averages: averages,
+		sob:      sob,
+		pb:       pb,
+	}
+}
+
+func getPB(runs []Run) (*PBStats, error) {
+	if len(runs) == 0 {
+		return nil, errors.New("no runs found")
+	}
+
+	var fastestRun *Run = nil
+	fastestTotal := time.Duration(0)
+	for i, run := range runs {
+		if !run.completed || len(run.splitPayloads) == 0 {
+			continue
+		}
+
+		total := run.splitPayloads[len(run.splitPayloads)-1].CurrentDuration
+		if fastestRun == nil || total < fastestTotal {
+			fastestRun = &runs[i]
+			fastestTotal = total
+		}
+	}
+
+	if fastestRun == nil {
+		return nil, errors.New("no completed runs found")
+	}
+
+	segsInBestRun := make([]SplitPayload, len(fastestRun.splitPayloads))
+	copy(segsInBestRun, fastestRun.splitPayloads)
+
+	payload := fastestRun.getPayload()
+	return &PBStats{
+		run:   &payload,
+		total: fastestTotal,
+	}, nil
+}
+
+func perSegmentAggregates(runs []Run) (golds, sums map[uuid.UUID]time.Duration, counts map[uuid.UUID]int) {
+	golds = make(map[uuid.UUID]time.Duration)
+	sums = make(map[uuid.UUID]time.Duration)
+	counts = make(map[uuid.UUID]int)
+
+	for _, run := range runs {
+		var last time.Duration
+		for i, s := range run.splitPayloads {
+			id, err := uuid.Parse(s.SplitSegmentID)
+			if err != nil {
+				logger.Error(fmt.Sprintf("failed to parse uuid for split payload in perSegmentAggregates: %s", err))
+				continue
+			}
+
+			segmentDuration := s.CurrentDuration - last
+			if segmentDuration < 0 {
+				logger.Warn(fmt.Sprintf("non-monotonic cumulative at split %d", i))
+				continue
+			}
+
+			last = s.CurrentDuration
+			if cur, ok := golds[id]; !ok || segmentDuration < cur {
+				golds[id] = segmentDuration
+			}
+
+			sums[id] += s.CurrentDuration
+			counts[id]++
+		}
+	}
+
+	return golds, sums, counts
+}

--- a/skin/service.go
+++ b/skin/service.go
@@ -15,7 +15,7 @@ type Service struct {
 	skinDir string
 }
 
-// Startup takes a context.Context passed by Wails.Run OnStartup and sets it to this Service.
+// Startup takes a context.Context passed by Wails.run OnStartup and sets it to this Service.
 func (s *Service) Startup(ctx context.Context, skinDir string) {
 	s.ctx = ctx
 	s.skinDir = skinDir

--- a/sysopen/service.go
+++ b/sysopen/service.go
@@ -23,7 +23,7 @@ func NewService(skinFolder string) *Service {
 	}
 }
 
-// Startup passes in a context from Wails.Run to allow the exec call to open a file explorer.
+// Startup passes in a context from Wails.run to allow the exec call to open a file explorer.
 //
 // Any other context will cause OpenFolder and OpenSkinsFolder to panic.
 func (s *Service) Startup(ctx context.Context) {

--- a/timer/service.go
+++ b/timer/service.go
@@ -39,7 +39,7 @@ func NewService(t TickerInterface) (*Service, chan time.Duration) {
 	}, timeUpdatedChannel
 }
 
-// Startup receives a context.Context from Wails.Run
+// Startup receives a context.Context from Wails.run
 func (s *Service) Startup(ctx context.Context) {
 	s.ctx = ctx
 	s.Run()

--- a/utils/timer.go
+++ b/utils/timer.go
@@ -21,7 +21,7 @@ func FormatTimeToString(d time.Duration) string {
 	s := d / time.Second
 	cs := (d - s*time.Second) / (10 * time.Millisecond) // centiseconds
 
-	return fmt.Sprintf("%s%d:%02d:%02d.%02d", sign, h, m, s, cs)
+	return fmt.Sprintf("%s%02d:%02d:%02d.%02d", sign, h, m, s, cs)
 }
 
 // ParseStringToTime unserializes a string, usually from the frontend, into a time.Duration.

--- a/utils/timer_test.go
+++ b/utils/timer_test.go
@@ -8,8 +8,14 @@ import (
 func TestFormatTimeToString(t *testing.T) {
 	d := time.Hour*1 + time.Minute*2 + time.Second*3 + time.Millisecond*400
 	timeString := FormatTimeToString(d)
-	if timeString != "1:02:03.40" {
-		t.Errorf("FormatTimeToString() got %s, want %s", timeString, "1:02:03.40")
+	if timeString != "01:02:03.40" {
+		t.Errorf("FormatTimeToString() got %s, want %s", timeString, "01:02:03.40")
+	}
+
+	d = time.Minute*2 + time.Second*3 + time.Millisecond*400
+	timeString = FormatTimeToString(d)
+	if timeString != "00:02:03.40" {
+		t.Errorf("FormatTimeToString() got %s, want %s", timeString, "00:02:03.40")
 	}
 }
 


### PR DESCRIPTION
## Summary
Standardizes time formats to be all strings on the frontend, all durations on the backend, with util functions for display on both sides.

Simplifies session service communication to frontend my removing "session:split" updates, which were redundant because the splitfile in the session payload also contains the segments and split data.

Store per segment stats in split file that are keyed to segment IDs to survive renames/moves.

## Screenshots/GIF (if UI)
<img width="376" height="575" alt="image" src="https://github.com/user-attachments/assets/c7fb161e-e09d-4f7c-87e0-bce7526d2d04" />


## Checklist
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

## Notes for reviewers
