### PR TITLE
Feat/segment countdown

### DIFF
--- a/frontend/src/components/editor/SplitEditor.tsx
+++ b/frontend/src/components/editor/SplitEditor.tsx
@@ -1,5 +1,5 @@
 import { session } from "../../../wailsjs/go/models";
-import React, {useEffect, useRef} from "react";
+import React, { useEffect, useRef } from "react";
 import { GetConfig, GetLoadedSplitFile, UpdateSplitFile } from "../../../wailsjs/go/session/Service";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -8,9 +8,9 @@ import SplitFilePayload = session.SplitFilePayload;
 import TimeRow from "./TimeRow";
 import { useNavigate } from "react-router";
 import { useClickOutside } from "../../hooks/useClickOutside";
-import {WindowCenter, WindowSetSize} from "../../../wailsjs/runtime";
+import { WindowCenter, WindowSetSize } from "../../../wailsjs/runtime";
 import useWindowResize from "../../hooks/useWindowResize";
-import {msToParts, partsToMS, TimeParts} from "../splitter/Timer";
+import { msToParts, partsToMS, TimeParts } from "../splitter/Timer";
 import StatTime = session.StatTime;
 
 type Game = {
@@ -46,7 +46,7 @@ export default function SplitEditor() {
 
     // Position and size the edit window
     useEffect(() => {
-        WindowSetSize(1000, 900)
+        WindowSetSize(1000, 900);
         WindowCenter();
     }, []);
 
@@ -100,27 +100,29 @@ export default function SplitEditor() {
                 name: "",
                 gold: StatTime.createFrom({
                     formatted: "",
-                    raw: 0
+                    raw: 0,
                 }),
                 average: StatTime.createFrom({
                     formatted: "",
-                    raw: 0
+                    raw: 0,
                 }),
                 pb: StatTime.createFrom({
                     formatted: "",
-                    raw: 0
+                    raw: 0,
                 }),
-            })
+            }),
         ]);
     };
 
     const updateSegments = (idx: number, attrName: string, attrVal: string) => {
-        setSegments((prev) => prev.map((s, i) => {
-            if (idx === i) {
-                return SegmentPayload.createFrom({...s, [attrName]: attrVal});
-            }
-            return s
-        }));
+        setSegments((prev) =>
+            prev.map((s, i) => {
+                if (idx === i) {
+                    return SegmentPayload.createFrom({ ...s, [attrName]: attrVal });
+                }
+                return s;
+            }),
+        );
     };
 
     const deleteSegment = (idx: number) => {
@@ -137,7 +139,7 @@ export default function SplitEditor() {
             attempts: Number(attempts),
         });
 
-        console.log(splitFilePayload)
+        console.log(splitFilePayload);
 
         UpdateSplitFile(splitFilePayload)
             .then(() => {
@@ -147,20 +149,28 @@ export default function SplitEditor() {
     };
 
     const handleTimeChange = (idx: number, time: TimeParts, isBest: boolean) => {
-        const ms = partsToMS(time)
-        setSegments((prev) => prev.map((s, i) => {
-            if (idx === i) {
-                return SegmentPayload.createFrom(
-                    {
-                        ...s,
-                        ...(isBest ? {average: StatTime.createFrom({
-                                raw: partsToMS(time)
-                            }) } : {best: StatTime.createFrom({
-                                raw: partsToMS(time)
-                            }) })});
+        const ms = partsToMS(time);
+        const newSegments = [];
+        for (let i = 0; i < segments.length; i++) {
+            if (idx != i) {
+                newSegments.push(SegmentPayload.createFrom(segments[i]));
+            } else {
+                const s = { ...segments[i] };
+                const pb = isBest ? StatTime.createFrom({ raw: ms }) : s.pb;
+                const avg = isBest ? s.average : StatTime.createFrom({ raw: ms });
+                newSegments.push(
+                    SegmentPayload.createFrom({
+                        id: s.id,
+                        name: s.name,
+                        gold: s.gold,
+                        pb: pb,
+                        average: avg,
+                    }),
+                );
             }
-            return s
-        }))
+        }
+
+        setSegments(newSegments);
     };
 
     return (
@@ -263,9 +273,7 @@ export default function SplitEditor() {
                                             <td style={{ textAlign: "center" }}>{idx + 1}</td>
                                             <td>
                                                 <input
-                                                    onChange={
-                                                        (e) => updateSegments(idx, "name", e.target.value)
-                                                    }
+                                                    onChange={(e) => updateSegments(idx, "name", e.target.value)}
                                                     value={segment.name}
                                                 />
                                             </td>

--- a/frontend/src/components/editor/SplitEditor.tsx
+++ b/frontend/src/components/editor/SplitEditor.tsx
@@ -1,5 +1,5 @@
 import { session } from "../../../wailsjs/go/models";
-import React, { useEffect, useRef } from "react";
+import React, {useEffect, useRef} from "react";
 import { GetConfig, GetLoadedSplitFile, UpdateSplitFile } from "../../../wailsjs/go/session/Service";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -8,8 +8,10 @@ import SplitFilePayload = session.SplitFilePayload;
 import TimeRow from "./TimeRow";
 import { useNavigate } from "react-router";
 import { useClickOutside } from "../../hooks/useClickOutside";
-import { WindowSetPosition, WindowSetSize } from "../../../wailsjs/runtime";
+import {WindowCenter, WindowSetSize} from "../../../wailsjs/runtime";
 import useWindowResize from "../../hooks/useWindowResize";
+import {msToParts, partsToMS, TimeParts} from "../splitter/Timer";
+import StatTime = session.StatTime;
 
 type Game = {
     id: string;
@@ -18,48 +20,37 @@ type Game = {
     released: string;
 };
 
-type Segment = {
-    id: string;
-    name: string;
-    average_time: string;
-    best_time: string;
-};
-
 export default function SplitEditor() {
+    // Set default window size and persist updates
     useWindowResize("edit");
+
+    // Clear model results which will close the modal when we click outside the modal
     const clickOutsideRef = useRef<HTMLDivElement | null>(null);
-    const navigate = useNavigate();
-    const [gameName, setGameName] = React.useState<string>("");
-    const [gameCategory, setGameCategory] = React.useState<string>("");
-    const [segments, setSegments] = React.useState<Segment[]>([]);
-    const [attempts, setAttempts] = React.useState<number>(0);
-    const [speedrunAPIBase, setSpeedrunAPIBase] = React.useState<string>("");
-    const [gameResults, setGameResults] = React.useState<Game[]>([]);
-    const timeoutID = useRef<number>(0);
     useClickOutside(clickOutsideRef, () => {
-        console.log("Click outside handler fired");
         setGameResults([]);
     });
 
-    useEffect(() => WindowSetSize(1000, 900), []);
+    // Allow us to change pages
+    const navigate = useNavigate();
 
+    // Segment stats
+    const [gameName, setGameName] = React.useState<string>("");
+    const [gameCategory, setGameCategory] = React.useState<string>("");
+    const [segments, setSegments] = React.useState<SegmentPayload[]>([]);
+    const [attempts, setAttempts] = React.useState<number>(0);
+
+    // Speedrun search
+    const [speedrunAPIBase, setSpeedrunAPIBase] = React.useState<string>("");
+    const [gameResults, setGameResults] = React.useState<Game[]>([]);
+    const timeoutID = useRef<number>(0);
+
+    // Position and size the edit window
     useEffect(() => {
-        (async () => {
-            const loadedSplitFile = await GetLoadedSplitFile();
-            if (loadedSplitFile === null) return;
-            setGameName(loadedSplitFile.game_name);
-            setGameCategory(loadedSplitFile.game_category);
-            setAttempts(loadedSplitFile.attempts);
-            setSegments(
-                loadedSplitFile
-                    ? loadedSplitFile?.segments.map((s, i) => {
-                          return { ...s, idx: i, average_time: s.average_time, best_time: s.best_time };
-                      })
-                    : [],
-            );
-        })();
+        WindowSetSize(1000, 900)
+        WindowCenter();
     }, []);
 
+    // Get configuration, namely the speedrun API base URL
     useEffect(() => {
         (async () => {
             const config = await GetConfig();
@@ -67,8 +58,16 @@ export default function SplitEditor() {
         })();
     }, []);
 
+    // Pull apart the segment times from the split file in a way our UI can use them.
     useEffect(() => {
-        WindowSetPosition(400, 100);
+        (async () => {
+            const loadedSplitFile = await GetLoadedSplitFile();
+            if (loadedSplitFile === null) return;
+            setGameName(loadedSplitFile.game_name);
+            setGameCategory(loadedSplitFile.game_category);
+            setAttempts(loadedSplitFile.attempts);
+            setSegments(loadedSplitFile.segments);
+        })();
     }, []);
 
     const searchSpeedrun = async () => {
@@ -96,17 +95,32 @@ export default function SplitEditor() {
     const addSegment = () => {
         setSegments((prev) => [
             ...prev,
-            {
-                average_time: "00:00:00.00",
-                best_time: "00:00:00.00",
+            SegmentPayload.createFrom({
                 id: "",
                 name: "",
-            },
+                gold: StatTime.createFrom({
+                    formatted: "",
+                    raw: 0
+                }),
+                average: StatTime.createFrom({
+                    formatted: "",
+                    raw: 0
+                }),
+                pb: StatTime.createFrom({
+                    formatted: "",
+                    raw: 0
+                }),
+            })
         ]);
     };
 
     const updateSegments = (idx: number, attrName: string, attrVal: string) => {
-        setSegments((prev) => prev.map((s, i) => (i === idx ? { ...s, [attrName]: attrVal } : s)));
+        setSegments((prev) => prev.map((s, i) => {
+            if (idx === i) {
+                return SegmentPayload.createFrom({...s, [attrName]: attrVal});
+            }
+            return s
+        }));
     };
 
     const deleteSegment = (idx: number) => {
@@ -123,6 +137,8 @@ export default function SplitEditor() {
             attempts: Number(attempts),
         });
 
+        console.log(splitFilePayload)
+
         UpdateSplitFile(splitFilePayload)
             .then(() => {
                 navigate("/");
@@ -130,18 +146,21 @@ export default function SplitEditor() {
             .catch((err) => console.log(err));
     };
 
-    const handleTimeChange = (idx: number, time: string, isBest: boolean) => {
-        setSegments((prev) =>
-            prev.map((s, i) =>
-                i === idx
-                    ? {
-                          ...s,
-                          best_time: isBest ? time : s.best_time,
-                          average_time: isBest ? s.average_time : time,
-                      }
-                    : s,
-            ),
-        );
+    const handleTimeChange = (idx: number, time: TimeParts, isBest: boolean) => {
+        const ms = partsToMS(time)
+        setSegments((prev) => prev.map((s, i) => {
+            if (idx === i) {
+                return SegmentPayload.createFrom(
+                    {
+                        ...s,
+                        ...(isBest ? {average: StatTime.createFrom({
+                                raw: partsToMS(time)
+                            }) } : {best: StatTime.createFrom({
+                                raw: partsToMS(time)
+                            }) })});
+            }
+            return s
+        }))
     };
 
     return (
@@ -223,7 +242,7 @@ export default function SplitEditor() {
                 </div>
                 <div className="datagrid-container">
                     <div className="datagrid">
-                        {segments.length > 0 && (
+                        {segments && segments.length > 0 && (
                             <table cellSpacing={0} className="datagrid" id="tbl-segments">
                                 <thead>
                                     <tr>
@@ -244,21 +263,23 @@ export default function SplitEditor() {
                                             <td style={{ textAlign: "center" }}>{idx + 1}</td>
                                             <td>
                                                 <input
-                                                    onChange={(e) => updateSegments(idx, "name", e.target.value)}
-                                                    value={segment.name ?? ""}
+                                                    onChange={
+                                                        (e) => updateSegments(idx, "name", e.target.value)
+                                                    }
+                                                    value={segment.name}
                                                 />
                                             </td>
                                             <td>
                                                 <TimeRow
                                                     idx={idx}
-                                                    time={segment.average_time}
+                                                    time={segment.average ? msToParts(segment.average.raw) : null}
                                                     onChangeCallback={(idx, ts) => handleTimeChange(idx, ts, false)}
                                                 />
                                             </td>
                                             <td>
                                                 <TimeRow
                                                     idx={idx}
-                                                    time={segment.best_time}
+                                                    time={segment.pb ? msToParts(segment.pb.raw) : null}
                                                     onChangeCallback={(idx, ts) => handleTimeChange(idx, ts, true)}
                                                 />
                                             </td>

--- a/frontend/src/components/editor/TimeRow.tsx
+++ b/frontend/src/components/editor/TimeRow.tsx
@@ -1,5 +1,5 @@
-import React, {ChangeEventHandler, useEffect, useRef} from "react";
-import {numeric, TimeParts} from "../splitter/Timer";
+import React, { ChangeEventHandler, useEffect, useRef } from "react";
+import { numeric, TimeParts } from "../splitter/Timer";
 
 type timeRowParams = {
     idx: number;
@@ -12,7 +12,7 @@ type timeRowElements = {
     minutes: HTMLInputElement | null;
     seconds: HTMLInputElement | null;
     centis: HTMLInputElement | null;
-}
+};
 
 export default function TimeRow({ idx, time, onChangeCallback }: timeRowParams) {
     // Get refs to all the parts so we can update all at once
@@ -20,29 +20,29 @@ export default function TimeRow({ idx, time, onChangeCallback }: timeRowParams) 
         hours: null,
         minutes: null,
         seconds: null,
-        centis: null
+        centis: null,
     });
 
     // Set initial values from the passed in timeParts
     useEffect(() => {
         let el = timeRef.current.hours;
         if (el) {
-            el.value = time?.hours.toString() ?? ""
+            el.value = time?.hours.toString() ?? "";
         }
 
         el = timeRef.current.minutes;
         if (el) {
-            el.value = time?.minutes.toString() ?? ""
+            el.value = time?.minutes.toString() ?? "";
         }
 
         el = timeRef.current.seconds;
         if (el) {
-            el.value = time?.seconds.toString() ?? ""
+            el.value = time?.seconds.toString() ?? "";
         }
 
         el = timeRef.current.centis;
         if (el) {
-            el.value = time?.centis.toString() ?? ""
+            el.value = time?.centis.toString() ?? "";
         }
     }, []);
 
@@ -52,37 +52,37 @@ export default function TimeRow({ idx, time, onChangeCallback }: timeRowParams) 
         let seconds = timeRef.current.seconds?.value ?? "0";
         let centis = timeRef.current.centis?.value ?? "0";
 
-        hours = numeric(hours) ? hours : ""
-        minutes = numeric(minutes) ? minutes : ""
-        seconds = numeric(seconds) ? seconds : ""
-        centis = numeric(centis) ? centis : ""
+        hours = numeric(hours) ? hours : "";
+        minutes = numeric(minutes) ? minutes : "";
+        seconds = numeric(seconds) ? seconds : "";
+        centis = numeric(centis) ? centis : "";
 
-        const hoursNum = numeric(hours.trim()) ? Number(hours) : 0
-        const minutesNum = Math.min(Math.max(numeric(minutes.trim()) ? Number(minutes) : 0, 0), 59)
-        const secondsNum = Math.min(Math.max(numeric(seconds.trim()) ? Number(seconds) : 0, 0), 59)
-        const centisNum = Math.min(Math.max(numeric(centis.trim()) ? Number(centis) : 0, 0), 99)
+        const hoursNum = numeric(hours.trim()) ? Number(hours) : 0;
+        const minutesNum = Math.min(Math.max(numeric(minutes.trim()) ? Number(minutes) : 0, 0), 59);
+        const secondsNum = Math.min(Math.max(numeric(seconds.trim()) ? Number(seconds) : 0, 0), 59);
+        const centisNum = Math.min(Math.max(numeric(centis.trim()) ? Number(centis) : 0, 0), 99);
 
         let el = timeRef.current.hours;
         if (el) {
-            el.value = hoursNum.toString() ?? ""
+            el.value = hoursNum.toString() ?? "";
         }
 
         el = timeRef.current.minutes;
         if (el) {
-            el.value = minutesNum.toString() ?? ""
+            el.value = minutesNum.toString() ?? "";
         }
 
         el = timeRef.current.seconds;
         if (el) {
-            el.value = secondsNum.toString() ?? ""
+            el.value = secondsNum.toString() ?? "";
         }
 
         el = timeRef.current.centis;
         if (el) {
-            el.value = centisNum.toString() ?? ""
+            el.value = centisNum.toString() ?? "";
         }
 
-        onChangeCallback(idx,{
+        onChangeCallback(idx, {
             negative: false,
             hours: hoursNum,
             minutes: minutesNum,
@@ -93,13 +93,37 @@ export default function TimeRow({ idx, time, onChangeCallback }: timeRowParams) 
 
     return (
         <div className="segment-time">
-            <input ref={(el) => { timeRef.current.hours = el }} placeholder="H" onChange={handleChange} />
+            <input
+                ref={(el) => {
+                    timeRef.current.hours = el;
+                }}
+                placeholder="H"
+                onChange={handleChange}
+            />
             <span>:</span>
-            <input ref={(el) => { timeRef.current.minutes = el }} placeholder="MM" onChange={handleChange} />
+            <input
+                ref={(el) => {
+                    timeRef.current.minutes = el;
+                }}
+                placeholder="MM"
+                onChange={handleChange}
+            />
             <span>:</span>
-            <input ref={(el) => { timeRef.current.seconds = el }} placeholder="SS" onChange={handleChange} />
+            <input
+                ref={(el) => {
+                    timeRef.current.seconds = el;
+                }}
+                placeholder="SS"
+                onChange={handleChange}
+            />
             <span>.</span>
-            <input ref={(el) => { timeRef.current.centis = el }} placeholder={"cc"} onChange={handleChange} />
+            <input
+                ref={(el) => {
+                    timeRef.current.centis = el;
+                }}
+                placeholder={"cc"}
+                onChange={handleChange}
+            />
         </div>
     );
 }

--- a/frontend/src/components/editor/TimeRow.tsx
+++ b/frontend/src/components/editor/TimeRow.tsx
@@ -1,58 +1,105 @@
-import React, { useEffect } from "react";
-import { stringToParts } from "../splitter/Timer";
+import React, {ChangeEventHandler, useEffect, useRef} from "react";
+import {numeric, TimeParts} from "../splitter/Timer";
 
 type timeRowParams = {
     idx: number;
-    time: string;
-    onChangeCallback: (idx: number, time: string) => void;
+    time: TimeParts | null;
+    onChangeCallback: (idx: number, time: TimeParts) => void;
 };
 
+type timeRowElements = {
+    hours: HTMLInputElement | null;
+    minutes: HTMLInputElement | null;
+    seconds: HTMLInputElement | null;
+    centis: HTMLInputElement | null;
+}
+
 export default function TimeRow({ idx, time, onChangeCallback }: timeRowParams) {
-    const [hours, setHours] = React.useState<string>("00");
-    const [minutes, setMinutes] = React.useState<string>("00");
-    const [seconds, setSeconds] = React.useState<string>("00");
-    const [centis, setCentis] = React.useState<string>("00");
+    // Get refs to all the parts so we can update all at once
+    const timeRef = useRef<timeRowElements>({
+        hours: null,
+        minutes: null,
+        seconds: null,
+        centis: null
+    });
 
+    // Set initial values from the passed in timeParts
     useEffect(() => {
-        onChangeCallback(idx, `${hours}:${minutes}:${seconds}.${centis}`);
-    }, [hours, minutes, seconds, centis, idx]);
+        let el = timeRef.current.hours;
+        if (el) {
+            el.value = time?.hours.toString() ?? ""
+        }
 
-    useEffect(() => {
-        const timeParts = stringToParts(time);
-        setHours(String(timeParts.hours));
-        setMinutes(String(timeParts.minutes));
-        setSeconds(String(timeParts.seconds));
-        setCentis(String(timeParts.centis));
+        el = timeRef.current.minutes;
+        if (el) {
+            el.value = time?.minutes.toString() ?? ""
+        }
+
+        el = timeRef.current.seconds;
+        if (el) {
+            el.value = time?.seconds.toString() ?? ""
+        }
+
+        el = timeRef.current.centis;
+        if (el) {
+            el.value = time?.centis.toString() ?? ""
+        }
     }, []);
 
-    const handleChange = (val: string, clamp: number, updateFunc: (val: string) => void) => {
-        if (!val) {
-            val = "00";
+    const handleChange = () => {
+        let hours = timeRef.current.hours?.value ?? "0";
+        let minutes = timeRef.current.minutes?.value ?? "0";
+        let seconds = timeRef.current.seconds?.value ?? "0";
+        let centis = timeRef.current.centis?.value ?? "0";
+
+        hours = numeric(hours) ? hours : ""
+        minutes = numeric(minutes) ? minutes : ""
+        seconds = numeric(seconds) ? seconds : ""
+        centis = numeric(centis) ? centis : ""
+
+        const hoursNum = numeric(hours.trim()) ? Number(hours) : 0
+        const minutesNum = Math.min(Math.max(numeric(minutes.trim()) ? Number(minutes) : 0, 0), 59)
+        const secondsNum = Math.min(Math.max(numeric(seconds.trim()) ? Number(seconds) : 0, 0), 59)
+        const centisNum = Math.min(Math.max(numeric(centis.trim()) ? Number(centis) : 0, 0), 99)
+
+        let el = timeRef.current.hours;
+        if (el) {
+            el.value = hoursNum.toString() ?? ""
         }
 
-        let numVal = parseInt(val, 10);
-        if (isNaN(numVal)) {
-            val = "00";
-            updateFunc(val);
-            return;
+        el = timeRef.current.minutes;
+        if (el) {
+            el.value = minutesNum.toString() ?? ""
         }
 
-        if (clamp > 0) {
-            numVal = Math.min(Math.max(numVal, 0), clamp);
+        el = timeRef.current.seconds;
+        if (el) {
+            el.value = secondsNum.toString() ?? ""
         }
 
-        updateFunc(String(numVal).padStart(2, "0"));
+        el = timeRef.current.centis;
+        if (el) {
+            el.value = centisNum.toString() ?? ""
+        }
+
+        onChangeCallback(idx,{
+            negative: false,
+            hours: hoursNum,
+            minutes: minutesNum,
+            seconds: secondsNum,
+            centis: centisNum,
+        });
     };
 
     return (
         <div className="segment-time">
-            <input placeholder="H" value={hours} onChange={(e) => handleChange(e.target.value, 0, setHours)} />
+            <input ref={(el) => { timeRef.current.hours = el }} placeholder="H" onChange={handleChange} />
             <span>:</span>
-            <input placeholder="MM" value={minutes} onChange={(e) => handleChange(e.target.value, 59, setMinutes)} />
+            <input ref={(el) => { timeRef.current.minutes = el }} placeholder="MM" onChange={handleChange} />
             <span>:</span>
-            <input placeholder="SS" value={seconds} onChange={(e) => handleChange(e.target.value, 59, setSeconds)} />
+            <input ref={(el) => { timeRef.current.seconds = el }} placeholder="SS" onChange={handleChange} />
             <span>.</span>
-            <input placeholder={"cc"} value={centis} onChange={(e) => handleChange(e.target.value, 99, setCentis)} />
+            <input ref={(el) => { timeRef.current.centis = el }} placeholder={"cc"} onChange={handleChange} />
         </div>
     );
 }

--- a/frontend/src/components/splitter/SplitList.tsx
+++ b/frontend/src/components/splitter/SplitList.tsx
@@ -1,6 +1,6 @@
 import { session } from "../../../wailsjs/go/models";
-import {displayFormattedTimeParts, formatDuration, msToParts, stringToParts} from "./Timer";
-import {JSX, useEffect, useState} from "react";
+import { displayFormattedTimeParts, formatDuration, msToParts, stringToParts } from "./Timer";
+import { JSX, useEffect, useState } from "react";
 import { GetLoadedSplitFile, GetSessionStatus } from "../../../wailsjs/go/session/Service";
 import { EventsOn } from "../../../wailsjs/runtime";
 import SplitFilePayload = session.SplitFilePayload;
@@ -49,7 +49,7 @@ export default function SplitList() {
                     servicePayload.current_run.split_payloads.map((c, _) => {
                         return {
                             time: displayFormattedTimeParts(formatDuration(stringToParts(c.current_time.formatted))),
-                            raw: c.current_time.raw
+                            raw: c.current_time.raw,
                         };
                     }),
                 );
@@ -60,16 +60,15 @@ export default function SplitList() {
     }, []);
 
     const getSegmentDisplayTime = (index: number, segment: SegmentPayload): JSX.Element => {
-        const gold = segment.gold?.raw
-        const average = segment.average?.raw
-        const best  = segment.pb?.raw
-        const target = compareAgainst == "average" ? average : best
+        const gold = segment.gold?.raw;
+        const average = segment.average?.raw;
+        const best = segment.pb?.raw;
+        const target = compareAgainst == "average" ? average : best;
 
         if (index < completions.length) {
-            let className = ""
-            if(gold && completions[index].raw < gold)
-            {
-                className = "timer-gold"
+            let className = "";
+            if (gold && completions[index].raw < gold) {
+                className = "timer-gold";
             } else {
                 if (target) {
                     if (completions[index].raw > target) {
@@ -82,32 +81,35 @@ export default function SplitList() {
                 }
             }
 
-            return (<strong className={className}>
-                {completions[index].time}
-            </strong>)
+            return <strong className={className}>{completions[index].time}</strong>;
         } else {
-            const diff = target - time;
-            console.log(diff)
-            let className = ""
+            const diff = time - target;
+            let className = "";
 
-            if(index === currentSegment && diff < 30000) {
-                if (time < target) {className = "timer-ahead"}
-                if (time > target) {className = "timer-behind"}
-                return <strong className={className}>
-                    {displayFormattedTimeParts(formatDuration(msToParts(diff), true))}
-                </strong>
+            if (index === currentSegment && diff > -30000) {
+                if (time < target) {
+                    className = "timer-ahead";
+                }
+                if (time > target) {
+                    className = "timer-behind";
+                }
+                return (
+                    <strong className={className}>
+                        {displayFormattedTimeParts(formatDuration(msToParts(diff), true))}
+                    </strong>
+                );
             }
 
-            return <strong className={className}>{displayFormattedTimeParts(formatDuration(msToParts(target)))}</strong>
+            return (
+                <strong className={className}>{displayFormattedTimeParts(formatDuration(msToParts(target)))}</strong>
+            );
         }
     };
 
     const segmentRows = splitFile?.segments?.map((segment, index) => (
         <tr key={segment.id ?? index} className={currentSegment !== null && currentSegment === index ? "selected" : ""}>
             <td className="splitName">{segment.name}</td>
-            <td className="splitComparison">
-                {getSegmentDisplayTime(index, segment)}
-            </td>
+            <td className="splitComparison">{getSegmentDisplayTime(index, segment)}</td>
         </tr>
     ));
 

--- a/frontend/src/components/splitter/SplitList.tsx
+++ b/frontend/src/components/splitter/SplitList.tsx
@@ -60,25 +60,24 @@ export default function SplitList() {
     }, []);
 
     const getSegmentDisplayTime = (index: number, segment: SegmentPayload): JSX.Element => {
+        const gold = segment.gold?.raw
+        const average = segment.average?.raw
+        const best  = segment.pb?.raw
+        const target = compareAgainst == "average" ? average : best
+
         if (index < completions.length) {
             let className = ""
-            if(splitFile && completions[index].raw < splitFile.stats.golds[segment.id]?.raw)
+            if(gold && completions[index].raw < gold)
             {
                 className = "timer-gold"
             } else {
-                if (splitFile) {
-                    const target = compareAgainst == "average" ?
-                        splitFile.stats.averages[segment.id].raw :
-                        splitFile.stats.pb?.run?.split_payloads.find(s =>
-                            s.split_segment_id === segment.id)?.current_time.raw
-                    if (target) {
-                        if (completions[index].raw > target) {
-                            className = "timer-behind";
-                        }
+                if (target) {
+                    if (completions[index].raw > target) {
+                        className = "timer-behind";
+                    }
 
-                        if (completions[index].raw < target) {
-                            className = "timer-ahead";
-                        }
+                    if (completions[index].raw < target) {
+                        className = "timer-ahead";
                     }
                 }
             }
@@ -87,39 +86,23 @@ export default function SplitList() {
                 {completions[index].time}
             </strong>)
         } else {
-            let val = ""
-            let raw = 0
-            if (compareAgainst == "average") {
-                if (splitFile && splitFile.stats.averages[segment.id]) {
-                    raw = splitFile.stats.averages[segment.id].raw;
-                    val = splitFile.stats.averages[segment.id].formatted;
-                } else {
-                    return <strong>-</strong>
-                }
-            } else {
-                const best = splitFile?.stats.pb?.run?.split_payloads.find((p) => p.split_segment_id === segment.id);
-                if (best) {
-                    raw = best.current_time.raw
-                    val = best.current_time.formatted;
-                } else {
-                    return <strong>-</strong>;
-                }
-            }
-
-            const diff = time - raw;
+            const diff = target - time;
+            console.log(diff)
             let className = ""
+
             if(index === currentSegment && diff < 30000) {
-                if (time < raw) {className = "timer-ahead"}
-                if (time > raw) {className = "timer-behind"}
+                if (time < target) {className = "timer-ahead"}
+                if (time > target) {className = "timer-behind"}
                 return <strong className={className}>
                     {displayFormattedTimeParts(formatDuration(msToParts(diff), true))}
                 </strong>
             }
-            return <strong className={className}>{displayFormattedTimeParts(formatDuration(stringToParts(val)))}</strong>
+
+            return <strong className={className}>{displayFormattedTimeParts(formatDuration(msToParts(target)))}</strong>
         }
     };
 
-    const segmentRows = splitFile?.segments.map((segment, index) => (
+    const segmentRows = splitFile?.segments?.map((segment, index) => (
         <tr key={segment.id ?? index} className={currentSegment !== null && currentSegment === index ? "selected" : ""}>
             <td className="splitName">{segment.name}</td>
             <td className="splitComparison">

--- a/frontend/src/components/splitter/Timer.tsx
+++ b/frontend/src/components/splitter/Timer.tsx
@@ -11,8 +11,8 @@ export type TimeParts = {
 };
 
 export type FormattedTimeParts = {
-    isNegative : boolean;
-    showSign : boolean;
+    isNegative: boolean;
+    showSign: boolean;
     showHours: boolean;
     showMinutes: boolean;
     padMinutes: boolean;
@@ -75,7 +75,7 @@ export function stringToParts(time: string): TimeParts {
     let negative = false;
     if (time[0] === "-") {
         negative = true;
-        time = time.slice(1)
+        time = time.slice(1);
     }
 
     const timeParts = time.split(":");
@@ -88,9 +88,9 @@ export function stringToParts(time: string): TimeParts {
     };
 }
 
-export function msToParts(ms: number) : TimeParts {
-    const negative = ms < 0
-    const abs = Math.abs(ms)
+export function msToParts(ms: number): TimeParts {
+    const negative = ms < 0;
+    const abs = Math.abs(ms);
     const totalSeconds = Math.floor(abs / 1000);
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
@@ -102,19 +102,19 @@ export function msToParts(ms: number) : TimeParts {
         minutes: minutes,
         seconds: seconds,
         centis: centis,
-        negative : negative,
+        negative: negative,
     };
 }
 
-export function partsToMS(parts: TimeParts) : number {
+export function partsToMS(parts: TimeParts): number {
     const negative = parts.negative;
-    let abs = 0
-    abs += parts.hours * 3600000
-    abs += parts.minutes * 60000
-    abs += parts.seconds * 1000
-    abs += parts.centis * 10
+    let abs = 0;
+    abs += parts.hours * 3600000;
+    abs += parts.minutes * 60000;
+    abs += parts.seconds * 1000;
+    abs += parts.centis * 10;
 
-    return negative ? abs * -1 : abs
+    return negative ? abs * -1 : abs;
 }
 
 export function formatDuration(timeParts: TimeParts, showSign: boolean = false): FormattedTimeParts {

--- a/frontend/src/components/splitter/Timer.tsx
+++ b/frontend/src/components/splitter/Timer.tsx
@@ -3,6 +3,7 @@ import { EventsOn } from "../../../wailsjs/runtime";
 import useWindowResize from "../../hooks/useWindowResize";
 
 export type TimeParts = {
+    negative: boolean;
     hours: number;
     minutes: number;
     seconds: number;
@@ -10,6 +11,8 @@ export type TimeParts = {
 };
 
 export type FormattedTimeParts = {
+    isNegative : boolean;
+    showSign : boolean;
     showHours: boolean;
     showMinutes: boolean;
     padMinutes: boolean;
@@ -69,8 +72,15 @@ export default function Timer() {
 }
 
 export function stringToParts(time: string): TimeParts {
+    let negative = false;
+    if (time[0] === "-") {
+        negative = true;
+        time = time.slice(1)
+    }
+
     const timeParts = time.split(":");
     return {
+        negative: negative,
         hours: Number(timeParts[0]),
         minutes: Number(timeParts[1]),
         seconds: Number(timeParts[2].split(".")[0]),
@@ -79,21 +89,24 @@ export function stringToParts(time: string): TimeParts {
 }
 
 export function msToParts(ms: number) {
-    const totalSeconds = Math.floor(ms / 1000);
+    const negative = ms < 0
+    const abs = Math.abs(ms)
+    const totalSeconds = Math.floor(abs / 1000);
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
-    const centis = Math.floor((ms % 1000) / 10);
+    const centis = Math.floor((abs % 1000) / 10);
 
     return {
         hours: hours,
         minutes: minutes,
         seconds: seconds,
         centis: centis,
+        negative : negative,
     };
 }
 
-export function formatDuration(timeParts: TimeParts): FormattedTimeParts {
+export function formatDuration(timeParts: TimeParts, showSign: boolean = false): FormattedTimeParts {
     // What to show
     const showHours = timeParts.hours > 0;
     const showMinutes = showHours ? true : timeParts.minutes > 0; // if hours>0 we show minutes (padded); else show only if minutes>0
@@ -116,6 +129,8 @@ export function formatDuration(timeParts: TimeParts): FormattedTimeParts {
     const sepSC = "."; // always show dot before centis
 
     return {
+        isNegative: timeParts.negative,
+        showSign: timeParts.negative || showSign,
         showHours: showHours,
         showMinutes: showMinutes,
         padMinutes: padMinutes,
@@ -132,6 +147,10 @@ export function formatDuration(timeParts: TimeParts): FormattedTimeParts {
 
 export function displayFormattedTimeParts(formattedParts: FormattedTimeParts): string {
     let timeString = "";
+    if (formattedParts.showSign) {
+        timeString = formattedParts.isNegative ? "-" : "+";
+    }
+    
     if (formattedParts.showHours) {
         timeString += formattedParts.hoursText;
     }

--- a/frontend/src/components/splitter/Timer.tsx
+++ b/frontend/src/components/splitter/Timer.tsx
@@ -88,7 +88,7 @@ export function stringToParts(time: string): TimeParts {
     };
 }
 
-export function msToParts(ms: number) {
+export function msToParts(ms: number) : TimeParts {
     const negative = ms < 0
     const abs = Math.abs(ms)
     const totalSeconds = Math.floor(abs / 1000);
@@ -104,6 +104,17 @@ export function msToParts(ms: number) {
         centis: centis,
         negative : negative,
     };
+}
+
+export function partsToMS(parts: TimeParts) : number {
+    const negative = parts.negative;
+    let abs = 0
+    abs += parts.hours * 3600000
+    abs += parts.minutes * 60000
+    abs += parts.seconds * 1000
+    abs += parts.centis * 10
+
+    return negative ? abs * -1 : abs
 }
 
 export function formatDuration(timeParts: TimeParts, showSign: boolean = false): FormattedTimeParts {
@@ -150,7 +161,7 @@ export function displayFormattedTimeParts(formattedParts: FormattedTimeParts): s
     if (formattedParts.showSign) {
         timeString = formattedParts.isNegative ? "-" : "+";
     }
-    
+
     if (formattedParts.showHours) {
         timeString += formattedParts.hoursText;
     }
@@ -162,3 +173,5 @@ export function displayFormattedTimeParts(formattedParts: FormattedTimeParts): s
     timeString += `${formattedParts.sepMS}${formattedParts.secondsText}${formattedParts.sepSC}${formattedParts.centisText}`;
     return timeString;
 }
+
+export const numeric = (s: string) => /^[+-]?\d+$/.test(s);

--- a/frontend/src/styles/splitter.css
+++ b/frontend/src/styles/splitter.css
@@ -43,12 +43,12 @@
     }
 
     .splitList table tr.selected {
-        background: #5b5557;
+        background: #000;
         color: #fff;
     }
 
     .splitList table td {
-        border: 2px solid #444;
+        border: 2px solid #333;
         border-left: 0;
         border-right: 0;
         padding: 5px;

--- a/frontend/src/styles/timer.css
+++ b/frontend/src/styles/timer.css
@@ -2,4 +2,17 @@
     .time-container {
         font-size: 50px;
     }
+
+    .timer-ahead {
+        color: greenyellow;
+    }
+
+    .timer-behind {
+        background-color: #000;
+        color: #f00;
+    }
+
+    .timer-gold {
+        color: gold;
+    }
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -12,6 +12,40 @@ export namespace session {
 	        this.speed_run_API_base = source["speed_run_API_base"];
 	    }
 	}
+	export class SplitPayload {
+	    split_index: number;
+	    split_segment_id: string;
+	    current_time: StatTime;
+	
+	    static createFrom(source: any = {}) {
+	        return new SplitPayload(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.split_index = source["split_index"];
+	        this.split_segment_id = source["split_segment_id"];
+	        this.current_time = this.convertValues(source["current_time"], StatTime);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class StatTime {
 	    raw: number;
 	    formatted: string;
@@ -26,28 +60,10 @@ export namespace session {
 	        this.formatted = source["formatted"];
 	    }
 	}
-	export class SplitPayload {
-	    split_index: number;
-	    split_segment_id: string;
-	    current_time: string;
-	    current_duration: number;
-	
-	    static createFrom(source: any = {}) {
-	        return new SplitPayload(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.split_index = source["split_index"];
-	        this.split_segment_id = source["split_segment_id"];
-	        this.current_time = source["current_time"];
-	        this.current_duration = source["current_duration"];
-	    }
-	}
 	export class RunPayload {
-	    id: number[];
+	    id: string;
 	    splitfile_version: number;
-	    total_time: number;
+	    total_time: StatTime;
 	    completed: boolean;
 	    split_payloads: SplitPayload[];
 	
@@ -59,7 +75,7 @@ export namespace session {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.splitfile_version = source["splitfile_version"];
-	        this.total_time = source["total_time"];
+	        this.total_time = this.convertValues(source["total_time"], StatTime);
 	        this.completed = source["completed"];
 	        this.split_payloads = this.convertValues(source["split_payloads"], SplitPayload);
 	    }
@@ -166,7 +182,7 @@ export namespace session {
 		}
 	}
 	export class SplitFilePayload {
-	    id: number[];
+	    id: string;
 	    version: number;
 	    game_name: string;
 	    game_category: string;
@@ -215,8 +231,7 @@ export namespace session {
 	    current_segment?: SegmentPayload;
 	    finished: boolean;
 	    paused: boolean;
-	    current_time: number;
-	    current_time_formatted: string;
+	    current_time: StatTime;
 	    current_run?: RunPayload;
 	
 	    static createFrom(source: any = {}) {
@@ -230,8 +245,7 @@ export namespace session {
 	        this.current_segment = this.convertValues(source["current_segment"], SegmentPayload);
 	        this.finished = source["finished"];
 	        this.paused = source["paused"];
-	        this.current_time = source["current_time"];
-	        this.current_time_formatted = source["current_time_formatted"];
+	        this.current_time = this.convertValues(source["current_time"], StatTime);
 	        this.current_run = this.convertValues(source["current_run"], RunPayload);
 	    }
 	

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -98,42 +98,12 @@ export namespace session {
 		    return a;
 		}
 	}
-	export class PBStatsPayload {
-	    run?: RunPayload;
-	    total: StatTime;
-	
-	    static createFrom(source: any = {}) {
-	        return new PBStatsPayload(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.run = this.convertValues(source["run"], RunPayload);
-	        this.total = this.convertValues(source["total"], StatTime);
-	    }
-	
-		convertValues(a: any, classs: any, asMap: boolean = false): any {
-		    if (!a) {
-		        return a;
-		    }
-		    if (a.slice && a.map) {
-		        return (a as any[]).map(elem => this.convertValues(elem, classs));
-		    } else if ("object" === typeof a) {
-		        if (asMap) {
-		            for (const key of Object.keys(a)) {
-		                a[key] = new classs(a[key]);
-		            }
-		            return a;
-		        }
-		        return new classs(a);
-		    }
-		    return a;
-		}
-	}
-	
 	export class SegmentPayload {
 	    id: string;
 	    name: string;
+	    gold: StatTime;
+	    average: StatTime;
+	    pb: StatTime;
 	
 	    static createFrom(source: any = {}) {
 	        return new SegmentPayload(source);
@@ -143,24 +113,9 @@ export namespace session {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.name = source["name"];
-	    }
-	}
-	export class SplitFileStatsPayload {
-	    golds: Record<string, StatTime>;
-	    averages: Record<string, StatTime>;
-	    sob: StatTime;
-	    pb?: PBStatsPayload;
-	
-	    static createFrom(source: any = {}) {
-	        return new SplitFileStatsPayload(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.golds = this.convertValues(source["golds"], StatTime, true);
-	        this.averages = this.convertValues(source["averages"], StatTime, true);
-	        this.sob = this.convertValues(source["sob"], StatTime);
-	        this.pb = this.convertValues(source["pb"], PBStatsPayload);
+	        this.gold = this.convertValues(source["gold"], StatTime);
+	        this.average = this.convertValues(source["average"], StatTime);
+	        this.pb = this.convertValues(source["pb"], StatTime);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -189,7 +144,7 @@ export namespace session {
 	    segments: SegmentPayload[];
 	    attempts: number;
 	    runs: RunPayload[];
-	    stats: SplitFileStatsPayload;
+	    SOB: StatTime;
 	
 	    static createFrom(source: any = {}) {
 	        return new SplitFilePayload(source);
@@ -204,7 +159,7 @@ export namespace session {
 	        this.segments = this.convertValues(source["segments"], SegmentPayload);
 	        this.attempts = source["attempts"];
 	        this.runs = this.convertValues(source["runs"], RunPayload);
-	        this.stats = this.convertValues(source["stats"], SplitFileStatsPayload);
+	        this.SOB = this.convertValues(source["SOB"], StatTime);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -267,7 +222,6 @@ export namespace session {
 		    return a;
 		}
 	}
-	
 	
 	
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -12,6 +12,20 @@ export namespace session {
 	        this.speed_run_API_base = source["speed_run_API_base"];
 	    }
 	}
+	export class StatTime {
+	    raw: number;
+	    formatted: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new StatTime(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.raw = source["raw"];
+	        this.formatted = source["formatted"];
+	    }
+	}
 	export class SplitPayload {
 	    split_index: number;
 	    split_segment_id: string;
@@ -70,7 +84,7 @@ export namespace session {
 	}
 	export class PBStatsPayload {
 	    run?: RunPayload;
-	    total: string;
+	    total: StatTime;
 	
 	    static createFrom(source: any = {}) {
 	        return new PBStatsPayload(source);
@@ -79,7 +93,7 @@ export namespace session {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.run = this.convertValues(source["run"], RunPayload);
-	        this.total = source["total"];
+	        this.total = this.convertValues(source["total"], StatTime);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -116,9 +130,9 @@ export namespace session {
 	    }
 	}
 	export class SplitFileStatsPayload {
-	    golds: Record<string, string>;
-	    averages: Record<string, string>;
-	    sob: string;
+	    golds: Record<string, StatTime>;
+	    averages: Record<string, StatTime>;
+	    sob: StatTime;
 	    pb?: PBStatsPayload;
 	
 	    static createFrom(source: any = {}) {
@@ -127,9 +141,9 @@ export namespace session {
 	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.golds = source["golds"];
-	        this.averages = source["averages"];
-	        this.sob = source["sob"];
+	        this.golds = this.convertValues(source["golds"], StatTime, true);
+	        this.averages = this.convertValues(source["averages"], StatTime, true);
+	        this.sob = this.convertValues(source["sob"], StatTime);
 	        this.pb = this.convertValues(source["pb"], PBStatsPayload);
 	    }
 	
@@ -159,7 +173,7 @@ export namespace session {
 	    segments: SegmentPayload[];
 	    attempts: number;
 	    runs: RunPayload[];
-	    Stats: SplitFileStatsPayload;
+	    stats: SplitFileStatsPayload;
 	
 	    static createFrom(source: any = {}) {
 	        return new SplitFilePayload(source);
@@ -174,7 +188,7 @@ export namespace session {
 	        this.segments = this.convertValues(source["segments"], SegmentPayload);
 	        this.attempts = source["attempts"];
 	        this.runs = this.convertValues(source["runs"], RunPayload);
-	        this.Stats = this.convertValues(source["Stats"], SplitFileStatsPayload);
+	        this.stats = this.convertValues(source["stats"], SplitFileStatsPayload);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -239,6 +253,7 @@ export namespace session {
 		    return a;
 		}
 	}
+	
 	
 	
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 		Title:     "OpenSplit",
 		Width:     1024,
 		Height:    768,
-		Frameless: true,
+		Frameless: false,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/session/config.go
+++ b/session/config.go
@@ -1,0 +1,6 @@
+package session
+
+// Config holds configuration options so that Service.GetConfig can work for both backend and frontend.
+type Config struct {
+	SpeedRunAPIBase string `json:"speed_run_API_base"`
+}

--- a/session/run.go
+++ b/session/run.go
@@ -30,9 +30,9 @@ type Run struct {
 //
 // getPayload, modify the payload, then send it to newRunFromPayload and persist the result of that to make changes.
 func (r *Run) getPayload() RunPayload {
-	splitPayloads := make([]SplitPayload, 0)
-	for _, s := range r.splits {
-		splitPayloads = append(splitPayloads, s.getPayload())
+	splitPayloads := make([]SplitPayload, len(r.splits))
+	for i, s := range r.splits {
+		splitPayloads[i] = s.getPayload()
 	}
 
 	return RunPayload{

--- a/session/run_test.go
+++ b/session/run_test.go
@@ -1,7 +1,0 @@
-package session
-
-import "testing"
-
-func TestRunFinished(t *testing.T) {
-
-}

--- a/session/segment.go
+++ b/session/segment.go
@@ -1,19 +1,28 @@
 package session
 
 import (
+	"time"
+
 	"github.com/google/uuid"
+	"github.com/zellydev-games/opensplit/utils"
 )
 
 // SegmentPayload is a snapshot of a given Segment useful for communicating state while protecting internal data.
 type SegmentPayload struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Gold    StatTime `json:"gold"`
+	Average StatTime `json:"average"`
+	PB      StatTime `json:"pb"`
 }
 
 // Segment represents a portion of a game that you want to time (e.g. "Level 1")
 type Segment struct {
-	id   uuid.UUID
-	name string
+	id      uuid.UUID
+	name    string
+	gold    time.Duration
+	average time.Duration
+	pb      time.Duration
 }
 
 // NewFromPayload creates a new Segment from the given SegmentPayload.
@@ -24,7 +33,13 @@ func NewFromPayload(payload SegmentPayload) Segment {
 	if payload.ID == "" {
 		payload.ID = uuid.New().String()
 	}
-	return Segment{id: uuid.MustParse(payload.ID), name: payload.Name}
+
+	return Segment{
+		id:      uuid.MustParse(payload.ID),
+		name:    payload.Name,
+		average: time.Duration(payload.Average.Raw) * time.Millisecond,
+		pb:      time.Duration(payload.PB.Raw) * time.Millisecond,
+	}
 }
 
 // GetPayload retrieves a SegmentPayload representing the state of the Segment
@@ -32,5 +47,17 @@ func (s *Segment) GetPayload() SegmentPayload {
 	return SegmentPayload{
 		ID:   s.id.String(),
 		Name: s.name,
+		Average: StatTime{
+			s.average.Milliseconds(),
+			utils.FormatTimeToString(s.average),
+		},
+		PB: StatTime{
+			s.pb.Milliseconds(),
+			utils.FormatTimeToString(s.pb),
+		},
+		Gold: StatTime{
+			s.gold.Milliseconds(),
+			utils.FormatTimeToString(s.gold),
+		},
 	}
 }

--- a/session/service.go
+++ b/session/service.go
@@ -246,6 +246,7 @@ func (s *Service) Reset() {
 	if s.loadedSplitFile != nil && s.currentRun != nil {
 		logger.Debug(fmt.Sprintf("appending run to splitfile: %v", s.currentRun))
 		s.loadedSplitFile.runs = append(s.loadedSplitFile.runs, *s.currentRun)
+		s.loadedSplitFile.BuildStats()
 	}
 
 	s.finished = false

--- a/session/service.go
+++ b/session/service.go
@@ -152,6 +152,12 @@ func (s *Service) Split() {
 		return
 	}
 
+	// TODO: Handle the case where the user just wants a stopwatch (i.e. no segments in a split file, or no split file loaded at all)
+	if len(s.loadedSplitFile.segments) == 0 {
+		logger.Debug("split called on a split file with no segments: NO-OP")
+		return
+	}
+
 	if s.finished {
 		s.Reset()
 		return
@@ -167,6 +173,7 @@ func (s *Service) Split() {
 			id:               uuid.New(),
 			splitFileVersion: s.loadedSplitFile.version,
 		}
+
 		s.currentSegmentIndex++
 		s.currentSegment = &s.loadedSplitFile.segments[s.currentSegmentIndex]
 		logger.Debug("sending session update from run start split")
@@ -257,7 +264,7 @@ func (s *Service) Reset() {
 
 // SaveSplitFile uses the configured Persister to save the SplitFile to the configured storage
 //
-// Use SaveSplitFile instead of UpdateSplitFile when you want to save new runs or Stats without changes to data
+// Use SaveSplitFile instead of UpdateSplitFile when you want to save new runs or BuildStats without changes to data
 // (e.g. NOT changing the Game Name, Category, or segments).
 // This function will never bump the split file version.
 func (s *Service) SaveSplitFile() error {

--- a/session/service.go
+++ b/session/service.go
@@ -14,11 +14,6 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-// Config holds configuration options so that Service.GetConfig can work for both backend and frontend.
-type Config struct {
-	SpeedRunAPIBase string `json:"speed_run_API_base"`
-}
-
 // GetConfig is designed to expose configuration options from the environment or other sources (config files) to the
 // frontend.  Go services can just read the environment, but the frontend has no reliable way to do so, so this func
 // is bound to the app in main which generates a typescript function for the frontend.
@@ -30,28 +25,6 @@ func (s *Service) GetConfig() *Config {
 	return &Config{
 		SpeedRunAPIBase: speedRunBase,
 	}
-}
-
-// ServicePayload is a snapshot of the session.Service, useful for communicating the state of the service to the frontend
-// without exposing internal data.
-type ServicePayload struct {
-	SplitFile            *SplitFilePayload `json:"split_file"`
-	CurrentSegmentIndex  int               `json:"current_segment_index"`
-	CurrentSegment       *SegmentPayload   `json:"current_segment"`
-	Finished             bool              `json:"finished"`
-	Paused               bool              `json:"paused"`
-	CurrentTime          time.Duration     `json:"current_time"`
-	CurrentTimeFormatted string            `json:"current_time_formatted"`
-	CurrentRun           *RunPayload       `json:"current_run"`
-}
-
-// SplitPayload is a snapshot of split data to communicate information about a split to the frontend, and also the
-// Run history in SplitFile runs
-type SplitPayload struct {
-	SplitIndex      int           `json:"split_index"`
-	SplitSegmentID  string        `json:"split_segment_id"`
-	CurrentTime     string        `json:"current_time"`
-	CurrentDuration time.Duration `json:"current_duration"`
 }
 
 // Persister is an interface that services that save and load splitfiles must implement to be used by session.Service
@@ -70,6 +43,18 @@ type Timer interface {
 	Reset()
 	GetCurrentTimeFormatted() string
 	GetCurrentTime() time.Duration
+}
+
+// ServicePayload is a snapshot of the session.Service, useful for communicating the state of the service to the frontend
+// without exposing internal data.
+type ServicePayload struct {
+	SplitFile           *SplitFilePayload `json:"split_file"`
+	CurrentSegmentIndex int               `json:"current_segment_index"`
+	CurrentSegment      *SegmentPayload   `json:"current_segment"`
+	Finished            bool              `json:"finished"`
+	Paused              bool              `json:"paused"`
+	CurrentTime         StatTime          `json:"current_time"`
+	CurrentRun          *RunPayload       `json:"current_run"`
 }
 
 // Service represents the interface from the backend Go system to the frontend React system.
@@ -195,10 +180,13 @@ func (s *Service) Split() {
 		return
 	} else if s.currentSegmentIndex >= len(s.loadedSplitFile.segments)-1 {
 		// run is finished
-		splitPayload := s.getSplitPayload()
 		s.timer.Pause()
 		s.finished = true
-		s.currentRun.splitPayloads = append(s.currentRun.splitPayloads, splitPayload)
+		s.currentRun.splits = append(s.currentRun.splits, Split{
+			splitIndex:      s.currentSegmentIndex,
+			splitSegmentID:  s.currentSegment.id,
+			currentDuration: s.timer.GetCurrentTime(),
+		})
 		s.currentRun.completed = true
 		s.currentRun.totalTime = s.timer.GetCurrentTime()
 		logger.Debug("split called with last segment in loaded split file, run complete")
@@ -207,8 +195,11 @@ func (s *Service) Split() {
 		return
 	} else {
 		// run is in progress
-		splitPayload := s.getSplitPayload()
-		s.currentRun.splitPayloads = append(s.currentRun.splitPayloads, splitPayload)
+		s.currentRun.splits = append(s.currentRun.splits, Split{
+			splitIndex:      s.currentSegmentIndex,
+			splitSegmentID:  s.currentSegment.id,
+			currentDuration: s.timer.GetCurrentTime(),
+		})
 		s.currentSegmentIndex++
 		s.currentSegment = &s.loadedSplitFile.segments[s.currentSegmentIndex]
 		logger.Debug("sending session update from mid run split")
@@ -409,25 +400,16 @@ func (s *Service) getServicePayload() ServicePayload {
 	}
 
 	payload := ServicePayload{
-		SplitFile:            loadedSplitFilePayload,
-		CurrentSegmentIndex:  s.currentSegmentIndex,
-		CurrentSegment:       currentSegmentPayload,
-		Finished:             s.finished,
-		CurrentTime:          s.timer.GetCurrentTime(),
-		CurrentTimeFormatted: s.timer.GetCurrentTimeFormatted(),
-		Paused:               !s.timer.IsRunning(),
-		CurrentRun:           currentRunPayload,
-	}
-
-	return payload
-}
-
-func (s *Service) getSplitPayload() SplitPayload {
-	var payload = SplitPayload{
-		SplitIndex:      s.currentSegmentIndex,
-		SplitSegmentID:  s.loadedSplitFile.segments[s.currentSegmentIndex].id.String(),
-		CurrentTime:     utils.FormatTimeToString(s.timer.GetCurrentTime()),
-		CurrentDuration: s.timer.GetCurrentTime(),
+		SplitFile:           loadedSplitFilePayload,
+		CurrentSegmentIndex: s.currentSegmentIndex,
+		CurrentSegment:      currentSegmentPayload,
+		Finished:            s.finished,
+		CurrentTime: StatTime{
+			Raw:       s.timer.GetCurrentTime().Milliseconds(),
+			Formatted: utils.FormatTimeToString(s.timer.GetCurrentTime()),
+		},
+		Paused:     !s.timer.IsRunning(),
+		CurrentRun: currentRunPayload,
 	}
 
 	return payload

--- a/session/service_test.go
+++ b/session/service_test.go
@@ -63,6 +63,7 @@ func (m *MockPersister) Startup(ctx context.Context) {
 func (m *MockPersister) Load() (SplitFilePayload, error) {
 	m.LoadCalled++
 	return SplitFilePayload{
+		ID:           uuid.New().String(),
 		GameName:     "Test Loaded Game",
 		GameCategory: "Test Loaded Category",
 		Segments: []SegmentPayload{{
@@ -71,7 +72,7 @@ func (m *MockPersister) Load() (SplitFilePayload, error) {
 		}},
 		Attempts: 50,
 		Runs: []RunPayload{{
-			ID:               uuid.MustParse("037ba872-2fdd-4531-aaee-101d777408b4"),
+			ID:               "037ba872-2fdd-4531-aaee-101d777408b4",
 			SplitFileVersion: 1,
 		}},
 	}, nil
@@ -293,7 +294,7 @@ func TestReset(t *testing.T) {
 func TestNewSplitFile(t *testing.T) {
 	s, _, _, _ := getService()
 	payload := SplitFilePayload{
-		ID:           uuid.UUID{},
+		ID:           uuid.New().String(),
 		Version:      0,
 		GameName:     "Test New Game",
 		GameCategory: "Test New Category",
@@ -304,8 +305,7 @@ func TestNewSplitFile(t *testing.T) {
 
 	s.loadedSplitFile = nil
 	_ = s.UpdateSplitFile(payload)
-	emptyUUID := uuid.UUID{}
-	if s.loadedSplitFile.id == emptyUUID {
+	if s.loadedSplitFile.id == uuid.Nil {
 		t.Error("session UpdateSplitFile did not create a new id with a new splitfile")
 	}
 

--- a/session/split.go
+++ b/session/split.go
@@ -1,0 +1,36 @@
+package session
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zellydev-games/opensplit/utils"
+)
+
+// SplitPayload is a snapshot of split data to communicate information about a split to the frontend, and also the
+// Run history in SplitFile runs
+type SplitPayload struct {
+	SplitIndex     int      `json:"split_index"`
+	SplitSegmentID string   `json:"split_segment_id"`
+	CurrentTime    StatTime `json:"current_time"`
+}
+
+// Split represents an advancement of a run through the segments.
+//
+// Split identifies a completed segment, and how long that segment took
+type Split struct {
+	splitIndex      int
+	splitSegmentID  uuid.UUID
+	currentDuration time.Duration
+}
+
+func (s *Split) getPayload() SplitPayload {
+	return SplitPayload{
+		SplitIndex:     s.splitIndex,
+		SplitSegmentID: s.splitSegmentID.String(),
+		CurrentTime: StatTime{
+			Raw:       s.currentDuration.Milliseconds(),
+			Formatted: utils.FormatTimeToString(s.currentDuration),
+		},
+	}
+}

--- a/session/splitfile.go
+++ b/session/splitfile.go
@@ -12,14 +12,14 @@ import (
 //
 // Used to communicate the state of a SplitFile to the frontend and Persister implementations without exposing internals.
 type SplitFilePayload struct {
-	ID           uuid.UUID             `json:"id"`
+	ID           string                `json:"id"`
 	Version      int                   `json:"version"`
 	GameName     string                `json:"game_name"`
 	GameCategory string                `json:"game_category"`
 	Segments     []SegmentPayload      `json:"segments"`
 	Attempts     int                   `json:"attempts"`
 	Runs         []RunPayload          `json:"runs"`
-	Stats        SplitFileStatsPayload `json:"Stats"`
+	Stats        SplitFileStatsPayload `json:"stats"`
 }
 
 // SplitFile represents the data and history of a game/category combo.
@@ -73,7 +73,7 @@ func (s *SplitFile) GetPayload() SplitFilePayload {
 		logger.Error(fmt.Sprintf("failed to get Stats payload: %s", err))
 	}
 	return SplitFilePayload{
-		ID:           s.id,
+		ID:           s.id.String(),
 		GameName:     s.gameName,
 		GameCategory: s.gameCategory,
 		Segments:     segmentPayloads,
@@ -100,13 +100,12 @@ func newFromPayload(payload SplitFilePayload) (*SplitFile, error) {
 		runs = append(runs, newRun)
 	}
 
-	var emptyUUID = uuid.UUID{}
-	if payload.ID == emptyUUID {
-		payload.ID = uuid.New()
+	if payload.ID == uuid.Nil.String() {
+		payload.ID = uuid.New().String()
 	}
 
 	return &SplitFile{
-		id:           payload.ID,
+		id:           uuid.MustParse(payload.ID),
 		gameName:     payload.GameName,
 		gameCategory: payload.GameCategory,
 		attempts:     payload.Attempts,

--- a/session/splitfile.go
+++ b/session/splitfile.go
@@ -100,7 +100,7 @@ func newFromPayload(payload SplitFilePayload) (*SplitFile, error) {
 		runs = append(runs, newRun)
 	}
 
-	if payload.ID == uuid.Nil.String() {
+	if payload.ID == uuid.Nil.String() || payload.ID == "" {
 		payload.ID = uuid.New().String()
 	}
 

--- a/session/stats_test.go
+++ b/session/stats_test.go
@@ -58,37 +58,43 @@ func TestGetStatsPayload(t *testing.T) {
 		}},
 	}}
 
-	stats := sf.Stats()
+	sf.BuildStats()
 	want := (sf.runs[0].splits[0].currentDuration +
 		sf.runs[1].splits[0].currentDuration +
 		sf.runs[2].splits[0].currentDuration) / 3
-	if stats.averages[sf.segments[0].id] != want {
-		t.Errorf("segment 1 average time: want %s got %s", want, stats.averages[sf.segments[0].id])
+	if sf.segments[0].average != want {
+		t.Errorf("segment 1 average time: want %s got %s", want, sf.segments[0].average)
 	}
 
 	want = (sf.runs[0].splits[1].currentDuration +
 		sf.runs[1].splits[1].currentDuration +
 		sf.runs[2].splits[1].currentDuration) / 3
-	if stats.averages[sf.segments[1].id] != want {
-		t.Errorf("segment 2 average time: want %s got %s", want, stats.averages[sf.segments[1].id])
+	if sf.segments[1].average != want {
+		t.Errorf("segment 2 average time: want %s got %s", want, sf.segments[1].average)
 	}
 
 	want = time.Second * 25
-	if stats.golds[sf.segments[0].id] != want {
-		t.Errorf("segment 1 gold want: %s got %s", want, stats.golds[sf.segments[0].id])
+	if sf.segments[0].gold != want {
+		t.Errorf("segment 1 gold want: %s got %s", want, sf.segments[0].gold)
 	}
 
 	want = time.Second * 4
-	if stats.golds[sf.segments[1].id] != want {
-		t.Errorf("segment 2 gold want: %s got %s", want, stats.golds[sf.segments[1].id])
+	if sf.segments[1].gold != want {
+		t.Errorf("segment 2 gold want: %s got %s", want, sf.segments[1].gold)
 	}
 
-	if stats.pb.run.id != rID3 {
-		t.Errorf("fastest run (PB) want id %s got %s", rID, stats.pb.run.id)
+	want = time.Second * 30
+	if sf.segments[0].pb != want {
+		t.Errorf("fastest run (PB) split 1 time want %s got %s", want, sf.segments[0].pb)
+	}
+
+	want = time.Second * 34
+	if sf.segments[1].pb != want {
+		t.Errorf("fastest run (PB) split 2 time want %s got %s", want, sf.segments[1].pb)
 	}
 
 	want = time.Second * 29
-	if stats.sob != want {
-		t.Errorf("sob want %s got %s", want, stats.sob)
+	if sf.sob != want {
+		t.Errorf("sob want %s got %s", want, sf.sob)
 	}
 }

--- a/session/stats_test.go
+++ b/session/stats_test.go
@@ -19,62 +19,56 @@ func TestGetStatsPayload(t *testing.T) {
 		splitFileVersion: 1,
 		totalTime:        time.Second * 35,
 		completed:        true,
-		splitPayloads: []SplitPayload{{
-			SplitIndex:      0,
-			SplitSegmentID:  sf.segments[0].id.String(),
-			CurrentTime:     "00:00:25.00",
-			CurrentDuration: time.Second * 25,
+		splits: []Split{{
+			splitIndex:      0,
+			splitSegmentID:  sf.segments[0].id,
+			currentDuration: time.Second * 25,
 		}, {
-			SplitIndex:      1,
-			SplitSegmentID:  sf.segments[1].id.String(),
-			CurrentTime:     "00:00:35.00",
-			CurrentDuration: time.Second * 35,
+			splitIndex:      1,
+			splitSegmentID:  sf.segments[1].id,
+			currentDuration: time.Second * 35,
 		}},
 	}, {
 		id:               rID2,
 		splitFileVersion: 1,
 		totalTime:        time.Second * 90,
 		completed:        true,
-		splitPayloads: []SplitPayload{{
-			SplitIndex:      0,
-			SplitSegmentID:  sf.segments[0].id.String(),
-			CurrentTime:     "00:01:00.00",
-			CurrentDuration: time.Second * 60,
+		splits: []Split{{
+			splitIndex:      0,
+			splitSegmentID:  sf.segments[0].id,
+			currentDuration: time.Second * 60,
 		}, {
-			SplitIndex:      1,
-			SplitSegmentID:  sf.segments[1].id.String(),
-			CurrentTime:     "00:01:30.00",
-			CurrentDuration: time.Second * 90,
+			splitIndex:      1,
+			splitSegmentID:  sf.segments[1].id,
+			currentDuration: time.Second * 90,
 		}},
 	}, {
 		id:               rID3,
 		splitFileVersion: 1,
 		totalTime:        time.Second * 34,
 		completed:        true,
-		splitPayloads: []SplitPayload{{
-			SplitIndex:      0,
-			SplitSegmentID:  sf.segments[0].id.String(),
-			CurrentTime:     "00:00:30.00",
-			CurrentDuration: time.Second * 30,
+		splits: []Split{{
+			splitIndex:      0,
+			splitSegmentID:  sf.segments[0].id,
+			currentDuration: time.Second * 30,
 		}, {
-			SplitIndex:      1,
-			SplitSegmentID:  sf.segments[1].id.String(),
-			CurrentTime:     "00:00:34.00",
-			CurrentDuration: time.Second * 34,
+			splitIndex:      1,
+			splitSegmentID:  sf.segments[1].id,
+			currentDuration: time.Second * 34,
 		}},
 	}}
 
 	stats := sf.Stats()
-	want := (sf.runs[0].splitPayloads[0].CurrentDuration +
-		sf.runs[1].splitPayloads[0].CurrentDuration +
-		sf.runs[2].splitPayloads[0].CurrentDuration) / 3
+	want := (sf.runs[0].splits[0].currentDuration +
+		sf.runs[1].splits[0].currentDuration +
+		sf.runs[2].splits[0].currentDuration) / 3
 	if stats.averages[sf.segments[0].id] != want {
 		t.Errorf("segment 1 average time: want %s got %s", want, stats.averages[sf.segments[0].id])
 	}
 
-	want = (sf.runs[0].splitPayloads[1].CurrentDuration +
-		sf.runs[1].splitPayloads[1].CurrentDuration +
-		sf.runs[2].splitPayloads[1].CurrentDuration) / 3
+	want = (sf.runs[0].splits[1].currentDuration +
+		sf.runs[1].splits[1].currentDuration +
+		sf.runs[2].splits[1].currentDuration) / 3
 	if stats.averages[sf.segments[1].id] != want {
 		t.Errorf("segment 2 average time: want %s got %s", want, stats.averages[sf.segments[1].id])
 	}
@@ -89,8 +83,8 @@ func TestGetStatsPayload(t *testing.T) {
 		t.Errorf("segment 2 gold want: %s got %s", want, stats.golds[sf.segments[1].id])
 	}
 
-	if stats.pb.run.ID != rID3 {
-		t.Errorf("fastest run (PB) want id %s got %s", rID, stats.pb.run.ID)
+	if stats.pb.run.id != rID3 {
+		t.Errorf("fastest run (PB) want id %s got %s", rID, stats.pb.run.id)
 	}
 
 	want = time.Second * 29

--- a/utils/timer.go
+++ b/utils/timer.go
@@ -50,3 +50,7 @@ func ParseStringToTime(s string) (time.Duration, error) {
 	}
 	return d, nil
 }
+
+func PayloadRawTimeToDuration(ms int64) time.Duration {
+	return time.Duration(ms) * time.Millisecond
+}


### PR DESCRIPTION
### Summary
Fixes segment time saving, fixes countdown display when inside 30 seconds of a split. Rebuilds stats on run finish/reset.


### Checklist
- [x] Prettier/fmt run (`task fmt`)
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

### Notes for reviewers
