### PR TITLE
Added repo close file to fix accidental overwrite when a previous fil…

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,12 +91,9 @@ func main() {
 			startInterruptListener(ctx, hotkeyService)
 			logger.Info("application startup complete")
 		},
-		OnShutdown: func(ctx context.Context) {
+		OnBeforeClose: func(ctx context.Context) bool {
 			sessionService.OnShutDown()
 			gracefulShutdown(hotkeyService)
-		},
-		OnBeforeClose: func(ctx context.Context) bool {
-			close(sessionUpdateChannel)
 			timerUIBridge.StopUIPump()
 			return false
 		},

--- a/repo/service.go
+++ b/repo/service.go
@@ -11,6 +11,7 @@ type Repository interface {
 	Load() ([]byte, error)
 	Save([]byte) error
 	SaveAs([]byte) error
+	ClearCachedFileName()
 }
 
 type Service struct {
@@ -40,4 +41,8 @@ func (s *Service) Save(splitFile *dto.SplitFile, X int, Y int, Width int, Height
 		return err
 	}
 	return s.repository.Save(payload)
+}
+
+func (s *Service) Close() {
+	s.repository.ClearCachedFileName()
 }

--- a/statemachine/running.go
+++ b/statemachine/running.go
@@ -37,6 +37,7 @@ func (r Running) Receive(command Command, params *string) (DispatchReply, error)
 	case CLOSE:
 		logger.Debug(fmt.Sprintf("Running received CLOSE command: %v", params))
 		machine.sessionService.CloseRun()
+		machine.repoService.Close()
 		machine.changeState(WELCOME, nil)
 	case EDIT:
 		logger.Debug(fmt.Sprintf("Running received EDIT command: %v", params))

--- a/timer/stopwatch_test.go
+++ b/timer/stopwatch_test.go
@@ -29,7 +29,7 @@ func TestRun(t *testing.T) {
 			t.Errorf("channel was not sent to")
 		}
 	}()
-	
+
 	base := time.Unix(0, 0)
 	s.startTime = base
 	mockT.ch <- time.Unix(0, 42e6)


### PR DESCRIPTION
…e is closed

### Summary
Adds functions to clear out the repo's cached filename when closing a file.  Previously if you loaded a file, the cached file name was never cleared, so creating and saving a new file after closing one would overwrite the closed one.

### Screenshots/GIF (if UI)
<!-- drag & drop here -->

### Checklist
- [x] Prettier/fmt run (`task fmt`)
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

### Notes for reviewers
