### PR TITLE
Added a check for splits without a target to display as dashes in the…

### DIFF
--- a/frontend/src/components/splitter/SplitList.tsx
+++ b/frontend/src/components/splitter/SplitList.tsx
@@ -75,6 +75,10 @@ export default function SplitList({ sessionPayload }: SplitListParameters) {
             }
             return <strong className={className}>{completion.time}</strong>;
         } else {
+            if (target === 0) {
+                return <>-</>;
+            }
+
             const diff = time - target;
             let className = "";
 


### PR DESCRIPTION
… split list

### Summary
Changes the target time in a split row to display a "-" if there is no target for that segment (i.e. the user has not completed that segment in a run yet)

### Screenshots/GIF (if UI)
<img width="491" height="697" alt="image" src="https://github.com/user-attachments/assets/ae63b91a-6513-437d-85fa-8b566d1e6cbc" />


### Checklist
- [x] Prettier/fmt run (`task fmt`)
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

### Notes for reviewers
