### PR TITLE
Dont show deltas or targets if no average

### DIFF
--- a/frontend/src/components/splitter/SegmentList.tsx
+++ b/frontend/src/components/splitter/SegmentList.tsx
@@ -56,8 +56,8 @@ const getDeltaDisplayTime = (delta: number, gold: boolean = false) => {
 const getSegmentDisplayTime = (
     segment: SegmentPayload,
     split: SplitPayload | null,
-    targetCumulative: number,
-    targetIndividual: number,
+    targetCumulative: number | null,
+    targetIndividual: number | null,
 ): JSX.Element => {
     const gold = segment.gold;
 
@@ -77,6 +77,10 @@ const getSegmentDisplayTime = (
     }
 
     // Default target display
+    if (targetCumulative == null) {
+        return <strong>-</strong>;
+    }
+
     const t = displayFormattedTimeParts(formatDuration(msToParts(targetCumulative)));
     return (
         <strong>
@@ -89,16 +93,16 @@ const getSegmentDisplayTime = (
 function segmentRow(
     segmentData: FlatSegment,
     split: SplitPayload | null,
-    cumulativeTarget: number,
-    individualTarget: number,
+    cumulativeTarget: number | null,
+    individualTarget: number | null,
     activeRow: boolean = false,
     time: number | null = null,
 ) {
     let delta: number | null = null;
 
-    if (split != null) {
+    if (split != null && cumulativeTarget) {
         delta = split.current_cumulative - cumulativeTarget;
-    } else if (activeRow && time !== null && time > cumulativeTarget - 60000) {
+    } else if (activeRow && time !== null && cumulativeTarget && time > cumulativeTarget - 60000) {
         delta = time - cumulativeTarget;
     }
 
@@ -142,16 +146,19 @@ export default function SegmentList({ sessionPayload, comparison }: SplitListPar
         const results: Targets = { cumulative: {}, individual: {} };
 
         sessionPayload.leaf_segments?.forEach((segment) => {
-            switch (comparison) {
-                case CompareAgainst.Average:
-                    results.individual[segment.id] = segment.average;
-                    break;
-                case CompareAgainst.Best:
-                    results.individual[segment.id] = segment.pb;
-                    break;
+            console.log(segment);
+            if (segment.average !== 0) {
+                switch (comparison) {
+                    case CompareAgainst.Average:
+                        results.individual[segment.id] = segment.average;
+                        break;
+                    case CompareAgainst.Best:
+                        results.individual[segment.id] = segment.pb;
+                        break;
+                }
+                results.cumulative[segment.id] = results.individual[segment.id] + cumulative;
+                cumulative += results.individual[segment.id];
             }
-            results.cumulative[segment.id] = results.individual[segment.id] + cumulative;
-            cumulative += results.individual[segment.id];
         });
 
         return results;


### PR DESCRIPTION
### Summary
Segment list was erroneously showing a cumulative target time even if the segment had no runs with a split.

### Screenshots/GIF (if UI)
<!-- drag & drop here -->

### Checklist
- [x] Prettier/fmt run (`task fmt`)
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

### Notes for reviewers
