### PR TITLE
Added reorderable segments

### DIFF
--- a/frontend/src/components/editor/SplitEditor.tsx
+++ b/frontend/src/components/editor/SplitEditor.tsx
@@ -87,7 +87,7 @@ type ParentRef = { node: SegmentPayload; siblings: SegmentPayload[]; index: numb
 function findNodeMutable(
     siblings: SegmentPayload[],
     id: string,
-    parents: ParentRef[] = []
+    parents: ParentRef[] = [],
 ): { siblings: SegmentPayload[]; index: number; parents: ParentRef[] } | null {
     for (let i = 0; i < siblings.length; i++) {
         const node = siblings[i];
@@ -110,11 +110,11 @@ function findNodeMutable(
  * - Accessible enough: uses title + aria-label + data-tooltip for CSS tooltip
  */
 function IconButton({
-                        icon,
-                        onClick,
-                        tooltip,
-                        show = true,
-                    }: {
+    icon,
+    onClick,
+    tooltip,
+    show = true,
+}: {
     icon: any;
     onClick: () => void;
     tooltip: string;
@@ -410,7 +410,12 @@ export default function SplitEditor({ splitFilePayload, speedRunAPIBase }: Split
      * - depth: indent depth
      * - inheritedGroupShade: shading applied because this row is a direct child of a grouped parent
      */
-    function renderRows(list: SegmentPayload[], depth: number, inheritedGroup: GroupCtx | null, isDirectChild: boolean) {
+    function renderRows(
+        list: SegmentPayload[],
+        depth: number,
+        inheritedGroup: GroupCtx | null,
+        isDirectChild: boolean,
+    ) {
         return list.map((segment, i) => {
             const hasChildren = (segment.children ?? []).length > 0;
 
@@ -457,8 +462,16 @@ export default function SplitEditor({ splitFilePayload, speedRunAPIBase }: Split
                     <tr className={rowClassName} style={rowStyle}>
                         <td>
                             <div style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: 6 }}>
-                                <IconButton icon={faArrowUp} tooltip="Move segment up" onClick={() => moveSegmentUp(segment.id)} />
-                                <IconButton icon={faArrowDown} tooltip="Move segment down" onClick={() => moveSegmentDown(segment.id)} />
+                                <IconButton
+                                    icon={faArrowUp}
+                                    tooltip="Move segment up"
+                                    onClick={() => moveSegmentUp(segment.id)}
+                                />
+                                <IconButton
+                                    icon={faArrowDown}
+                                    tooltip="Move segment down"
+                                    onClick={() => moveSegmentDown(segment.id)}
+                                />
                                 <IconButton
                                     icon={faArrowUpFromBracket}
                                     tooltip="Group under the segment above"
@@ -475,7 +488,10 @@ export default function SplitEditor({ splitFilePayload, speedRunAPIBase }: Split
                         </td>
 
                         <td style={{ paddingLeft: depth * 20 }}>
-                            <input value={segment.name} onChange={(e) => updateSegmentName(segment.id, e.target.value)} />
+                            <input
+                                value={segment.name}
+                                onChange={(e) => updateSegmentName(segment.id, e.target.value)}
+                            />
                         </td>
 
                         <td>
@@ -503,7 +519,11 @@ export default function SplitEditor({ splitFilePayload, speedRunAPIBase }: Split
                         </td>
 
                         <td>
-                            <IconButton icon={faTrash} tooltip="Delete segment" onClick={() => deleteSegment(segment.id)} />
+                            <IconButton
+                                icon={faTrash}
+                                tooltip="Delete segment"
+                                onClick={() => deleteSegment(segment.id)}
+                            />
                         </td>
                     </tr>
 
@@ -609,18 +629,18 @@ export default function SplitEditor({ splitFilePayload, speedRunAPIBase }: Split
                         {segments && segments.length > 0 && (
                             <table cellSpacing={0} className="datagrid" id="tbl-segments">
                                 <thead>
-                                <tr>
-                                    <th style={{ width: "5%" }}>#</th>
-                                    <th style={{ width: "50%" }}>Segment Name</th>
-                                    <th>
-                                        Average Time <small>(HH:MM:SS.ccc)</small>
-                                    </th>
-                                    <th>
-                                        Personal Best <small>(HH:MM:SS.ccc)</small>
-                                    </th>
-                                    <th style={{ width: "5%" }}>Add Subsegment</th>
-                                    <th style={{ width: "5%" }}></th>
-                                </tr>
+                                    <tr>
+                                        <th style={{ width: "5%" }}>#</th>
+                                        <th style={{ width: "50%" }}>Segment Name</th>
+                                        <th>
+                                            Average Time <small>(HH:MM:SS.ccc)</small>
+                                        </th>
+                                        <th>
+                                            Personal Best <small>(HH:MM:SS.ccc)</small>
+                                        </th>
+                                        <th style={{ width: "5%" }}>Add Subsegment</th>
+                                        <th style={{ width: "5%" }}></th>
+                                    </tr>
                                 </thead>
                                 <tbody>{renderRows(segments, 0, null, false)}</tbody>
                             </table>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -66,13 +66,15 @@
     white-space: nowrap;
     padding: 4px 8px;
     border-radius: 4px;
-    background: rgba(0,0,0,0.85);
+    background: rgba(0, 0, 0, 0.85);
     color: #fff;
     font-size: 12px;
     pointer-events: none;
     opacity: 0;
     visibility: hidden;
-    transition: opacity 120ms ease, visibility 120ms ease;
+    transition:
+        opacity 120ms ease,
+        visibility 120ms ease;
     z-index: 9999;
 }
 
@@ -84,9 +86,15 @@
     z-index: 9999;
 }
 
-.group-shade-0 > td { background: rgba(80, 120, 255, 0.08); }
-.group-shade-1 > td { background: rgba(80, 255, 160, 0.08); }
-.group-shade-2 > td { background: rgba(255, 200, 80, 0.10); }
+.group-shade-0 > td {
+    background: rgba(80, 120, 255, 0.08);
+}
+.group-shade-1 > td {
+    background: rgba(80, 255, 160, 0.08);
+}
+.group-shade-2 > td {
+    background: rgba(255, 200, 80, 0.1);
+}
 
 /* Uses the per-row CSS variable set by renderRows */
 .seg-group > td {


### PR DESCRIPTION
### Summary
Segments can now be re-ordered and segment groups have a background color to help distinguish them.

### Screenshots/GIF (if UI)
<!-- drag & drop here -->

### Checklist
- [x] Prettier/fmt run (`task fmt`)
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

### Notes for reviewers
