### PR TITLE
Added sum of best comparison

### DIFF
--- a/frontend/src/components/splitter/SegmentList.tsx
+++ b/frontend/src/components/splitter/SegmentList.tsx
@@ -176,6 +176,8 @@ export default function SegmentList({ sessionPayload, comparison }: SplitListPar
                     case CompareAgainst.Best:
                         results.individual[segment.id] = segment.pb;
                         break;
+                    case CompareAgainst.SumOfBest:
+                        results.individual[segment.id] = segment.gold;
                 }
                 results.cumulative[segment.id] = results.individual[segment.id] + cumulative;
                 cumulative += results.individual[segment.id];

--- a/frontend/src/components/splitter/Splitter.tsx
+++ b/frontend/src/components/splitter/Splitter.tsx
@@ -13,9 +13,10 @@ import Timer from "./Timer";
 export enum CompareAgainst {
     Best = "best",
     Average = "average",
+    SumOfBest = "sumOfBest",
 }
 
-export type Comparison = CompareAgainst.Best | CompareAgainst.Average;
+export type Comparison = CompareAgainst.Best | CompareAgainst.Average | CompareAgainst.SumOfBest;
 
 type SplitterParams = {
     sessionPayload: SessionPayload;
@@ -32,7 +33,7 @@ export default function Splitter({ sessionPayload, configPayload }: SplitterPara
         (async () => {
             setContextMenuItems(await buildContextMenu());
         })();
-    }, [globalHotkeys]);
+    }, [globalHotkeys, comparison]);
 
     useEffect(() => {
         (async () => {
@@ -77,16 +78,23 @@ export default function Splitter({ sessionPayload, configPayload }: SplitterPara
         contextMenuItems.push({ type: "separator" });
 
         contextMenuItems.push({
-            label: "Compare Against Average",
+            label: (comparison == CompareAgainst.Average ? "✓ " : "") + "Compare Against Average",
             onClick: () => {
                 setComparison(CompareAgainst.Average);
             },
         });
 
         contextMenuItems.push({
-            label: "Compare Against Best",
+            label: (comparison == CompareAgainst.Best ? "✓ " : "") + "Compare Against Best Run",
             onClick: () => {
                 setComparison(CompareAgainst.Best);
+            },
+        });
+
+        contextMenuItems.push({
+            label: (comparison == CompareAgainst.SumOfBest ? "✓ " : "") + "Compare Against Sum of Best Segments",
+            onClick: () => {
+                setComparison(CompareAgainst.SumOfBest);
             },
         });
 


### PR DESCRIPTION
### Summary
Adds a context menu option to show sum of best segments as target/comparison

### Screenshots/GIF (if UI)
<!-- drag & drop here -->

### Checklist
- [x] Prettier/fmt run (`task fmt`)
- [x] Tests pass (`task test`)
- [x] Lint passes (`task lint`)
- [x] Docs/README updated (if needed)
- [x] Linked issue (if any): Fixes #

### Notes for reviewers
